### PR TITLE
Fix for angular-cli(jit)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 # Development
 compiled
 docs
-src
 
 # TypeScript
 tsconfig.json

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "url": "https://github.com/dschnelldavis/angular2-json-schema-form/issues"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "src/"
   ],
-  "main": "dist/library/json-schema-form.module.js",
-  "typings": "dist/library/json-schema-form.module.d.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "clean:dist": "rimraf compiled && rimraf dist",
     "clean:all": "npm run clean:dist && rimraf node_modules && npm cache clean",

--- a/src/frameworks/bootstrap-3.component.ts
+++ b/src/frameworks/bootstrap-3.component.ts
@@ -99,7 +99,7 @@ import {
 
     <div *ngIf="debug && debugOutput">debug: <pre>{{debugOutput}}</pre></div>
   `,
-  styleUrls: [`
+  styles: [`
     :host /deep/ .list-group-item .form-control-feedback { top: 40; }
     :host /deep/ .checkbox,
     :host /deep/ .radio { margin-top: 0; margin-bottom: 0; }

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -5,7 +5,7 @@ import { Foundation6Component } from './foundation-6.component';
 import { MaterialDesignComponent } from './material-design/material-design.component';
 import { SemanticUIComponent } from './semantic-ui.component';
 
-export let ALL_FRAMEWORKS = [
+export const ALL_FRAMEWORKS = [
   NoFrameworkComponent, Bootstrap3Component, Bootstrap4Component,
   Foundation6Component, MaterialDesignComponent, SemanticUIComponent
 ];

--- a/src/frameworks/material-design/index.ts
+++ b/src/frameworks/material-design/index.ts
@@ -13,7 +13,7 @@ import { MaterialSelectComponent } from './material-select.component';
 import { MaterialTabsComponent } from './material-tabs.component';
 import { MaterialTextareaComponent } from './material-textarea.component';
 
-export let ALL_MATERIAL_DESIGN_WIDGETS = [
+export const ALL_MATERIAL_DESIGN_WIDGETS = [
   MaterialAddReferenceComponent, MaterialButtonComponent,
   MaterialCardComponent, MaterialCheckboxComponent,
   MaterialCheckboxesComponent, MaterialFileComponent,

--- a/src/library/json-schema-form.module.ts
+++ b/src/library/json-schema-form.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders, ANALYZE_FOR_ENTRY_COMPONENTS } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '@angular/material';
@@ -24,23 +24,46 @@ export {
   JsonSchemaFormComponent
 };
 
+const COMPONENTS = [
+  ...ALL_FRAMEWORKS,
+  ...ALL_WIDGETS,
+  ...ALL_MATERIAL_DESIGN_WIDGETS,
+];
+
 @NgModule({
   imports: [
-    CommonModule, FormsModule, ReactiveFormsModule, MaterialModule.forRoot()
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MaterialModule,
   ],
   declarations: [
-    JsonSchemaFormComponent, OrderableDirective,
-    ...ALL_FRAMEWORKS, ...ALL_WIDGETS, ...ALL_MATERIAL_DESIGN_WIDGETS
-  ],
-  entryComponents: [
-    ...ALL_FRAMEWORKS, ...ALL_WIDGETS, ...ALL_MATERIAL_DESIGN_WIDGETS
+    JsonSchemaFormComponent,
+    OrderableDirective,
+    ...COMPONENTS,
   ],
   exports: [
-    JsonSchemaFormComponent
-  ],
-  providers: [
-    FrameworkLibraryService, WidgetLibraryService, JsonSchemaFormService
+    FormsModule,
+    ReactiveFormsModule,
+    MaterialModule,
+    JsonSchemaFormComponent,
+    OrderableDirective,
   ],
 })
-export class JsonSchemaFormModule { }
-export default JsonSchemaFormModule;
+export class JsonSchemaFormModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: JsonSchemaFormModule,
+      providers: [
+        FrameworkLibraryService,
+        WidgetLibraryService,
+        JsonSchemaFormService,
+        {
+          provide: ANALYZE_FOR_ENTRY_COMPONENTS,
+          useValue: [...COMPONENTS],
+          multi: true,
+        },
+      ],
+    };
+  }
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -21,7 +21,7 @@ import { TabsComponent } from './tabs.component';
 import { TemplateComponent } from './template.component';
 import { TextareaComponent } from './textarea.component';
 
-export let ALL_WIDGETS: any[] = [
+export const ALL_WIDGETS = [
   AddReferenceComponent, ButtonComponent, CheckboxComponent,
   CheckboxesComponent, FieldsetComponent, FileComponent, HiddenComponent,
   InputComponent, MessageComponent, NoneComponent, NumberComponent,

--- a/src/widgets/root.component.ts
+++ b/src/widgets/root.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'root-widget',
   template: `
-    <div *ngFor="let layoutItem of layout; let i = index; trackBy: layoutItem?._id"
+    <div *ngFor="let layoutItem of layout; let i = index; trackBy: trackByItem"
       [dataIndex]="layoutItem?.arrayItem ? (dataIndex || []).concat(i) : (dataIndex || [])"
       [layoutIndex]="(layoutIndex || []).concat(i)"
       [layoutNode]="layoutItem"
@@ -33,4 +33,6 @@ export class RootComponent {
   @Input() layoutIndex: number[];
   @Input() layout: any[];
   @Input() isOrderable: boolean;
+
+  trackByItem(layoutItem: any) { return layoutItem && layoutItem._id; }
 }

--- a/src/widgets/tabs.component.ts
+++ b/src/widgets/tabs.component.ts
@@ -4,7 +4,6 @@ import { JsonSchemaFormService } from '../library/json-schema-form.service';
 import { JsonPointer } from '../library/utilities/index';
 
 @Component({
-  moduleId: module.id,
   selector: 'tabs-widget',
   template: `
     <ul

--- a/src/widgets/template.component.ts
+++ b/src/widgets/template.component.ts
@@ -6,7 +6,6 @@ import {
 import { JsonSchemaFormService } from '../library/json-schema-form.service';
 
 @Component({
-  moduleId: module.id,
   selector: 'template-widget',
   template: `<div #widgetContainer></div>`,
 })

--- a/src/widgets/textarea.component.ts
+++ b/src/widgets/textarea.component.ts
@@ -4,7 +4,6 @@ import { AbstractControl } from '@angular/forms';
 import { JsonSchemaFormService } from '../library/json-schema-form.service';
 
 @Component({
-  moduleId: module.id,
   selector: 'textarea-widget',
   template: `
     <div


### PR DESCRIPTION
Fix trackBy for RootComponent.
Fix styles for Bootstrap3Component.
Add src/ to publish.
Only work when using angular2-json-schema-form/src.
Only work with jit.
Remove moduleId.
Remove default export from module, maybe we want to support aot later.

We must add below to root module:
```typescript
import { JsonSchemaFormModule } from 'angular2-json-schema-form/src';

    MaterialModule.forRoot(),
    JsonSchemaFormModule.forRoot(),
```