### PR TITLE
Fix issue: material checkbox not initialized with controlValue

### DIFF
--- a/src/frameworks/material-design/material-checkbox.component.ts
+++ b/src/frameworks/material-design/material-checkbox.component.ts
@@ -12,6 +12,7 @@ import { JsonSchemaFormService } from '../../library/json-schema-form.service';
       [disabled]="controlDisabled || options?.readonly"
       [id]="'control' + layoutNode?._id"
       [name]="controlName"
+      [checked]="controlValue"
       (change)="updateValue($event)">
       <span *ngIf="options?.title"
         [class.sr-only]="options?.notitle"


### PR DESCRIPTION
When you load the form with the material-design framework and some data, the checkboxes are not initialized with the values.