### PR TITLE
Fixes for using Angular Material beta12 #107

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@angular/flex-layout": "2.0.0-beta.9",
     "@angular/forms": "^4.4.1",
     "@angular/http": "^4.4.1",
-    "@angular/material": "^2.0.0-beta.10",
+    "@angular/material": "^2.0.0-beta.12",
     "@angular/platform-browser": "^4.4.1",
     "@angular/platform-browser-dynamic": "^4.4.1",
     "@angular/router": "^4.4.1",

--- a/src/demo/app/demo.component.html
+++ b/src/demo/app/demo.component.html
@@ -1,7 +1,7 @@
 <div class="demo-page-header">
-  <md-toolbar class="mat-elevation-z4 mat-medium" color="primary">
+  <mat-toolbar class="mat-elevation-z4 mat-medium" color="primary">
     Angular JSON Schema Form — Demonstration Playground
-  </md-toolbar>
+  </mat-toolbar>
   <div class="header-content">
     An Angular <a href="http://json-schema.org/">JSON Schema</a> Form builder
     for Angular 4, similar to, and mostly API compatible with,
@@ -22,90 +22,90 @@
     Choose an example, or create your own, and check out the generated form.<br><br>
 
     <span class="menu-label">Current example:</span>
-    <button md-raised-button
+    <button mat-raised-button
       color="primary"
-      [mdMenuTriggerFor]="exampleMenu">
-      <md-icon>menu</md-icon> {{selectedSetName}} {{selectedExampleName}}
+      [matMenuTriggerFor]="exampleMenu">
+      <mat-icon>menu</mat-icon> {{selectedSetName}} {{selectedExampleName}}
     </button>
-    <md-menu #exampleMenu="mdMenu" class="example-menu">
-      <button md-menu-item class="mat-medium"
+    <mat-menu #exampleMenu="matMenu" class="example-menu">
+      <button mat-menu-item class="mat-medium"
         *ngFor="let example of examples['ng-jsf'].schemas"
         (click)="loadSelectedExample('ng-jsf', '', example.file, example.name)">
         {{example.name}}
       </button>
-      <button md-menu-item class="mat-medium" [mdMenuTriggerFor]="asfMenu">
+      <button mat-menu-item class="mat-medium" [matMenuTriggerFor]="asfMenu">
         <span>Angular Schema Form (AngularJS) examples</span>
       </button>
-      <md-menu #asfMenu="mdMenu" class="example-menu">
-        <button md-menu-item class="mat-medium"
+      <mat-menu #asfMenu="matMenu" class="example-menu">
+        <button mat-menu-item class="mat-medium"
           *ngFor="let example of examples.asf.schemas"
           (click)="loadSelectedExample('asf', 'Angular Schema Form:', example.file, example.name)">
           {{example.name}}
         </button>
-      </md-menu>
-      <button md-menu-item class="mat-medium" [mdMenuTriggerFor]="rjsfMenu">
+      </mat-menu>
+      <button mat-menu-item class="mat-medium" [matMenuTriggerFor]="rjsfMenu">
         <span>React JSON Schema Form examples</span>
       </button>
-      <md-menu #rjsfMenu="mdMenu" class="example-menu">
-        <button md-menu-item class="mat-medium"
+      <mat-menu #rjsfMenu="matMenu" class="example-menu">
+        <button mat-menu-item class="mat-medium"
           *ngFor="let example of examples.rjsf.schemas"
           (click)="loadSelectedExample('rjsf', 'React JSON Schema Form:', example.file, example.name)">
           {{example.name}}
         </button>
-      </md-menu>
-      <button md-menu-item class="mat-medium" [mdMenuTriggerFor]="jsfMenu">
+      </mat-menu>
+      <button mat-menu-item class="mat-medium" [matMenuTriggerFor]="jsfMenu">
         <span>JSONForm (jQuery) examples</span>
       </button>
-      <md-menu #jsfMenu="mdMenu" class="example-menu">
-        <button md-menu-item class="mat-medium"
+      <mat-menu #jsfMenu="matMenu" class="example-menu">
+        <button mat-menu-item class="mat-medium"
           *ngFor="let example of examples.jsf.schemas"
           (click)="loadSelectedExample('jsf', 'JSONForm:', example.file, example.name)">
           {{example.name}}
         </button>
-      </md-menu>
-    </md-menu>
+      </mat-menu>
+    </mat-menu>
   </div>
 </div>
 <div fxLayout="row" fxLayoutAlign="space-around start"
   fxLayout.lt-sm="column" fxLayoutAlign.lt-sm="flex-start center">
 
-  <md-card fxFlex="0 0 calc(50% - 12px)">
+  <mat-card fxFlex="0 0 calc(50% - 12px)">
     <h4 class="defualt-cursor" (click)="toggleVisible('options')">
       {{visible.options ? '▼' : '▶'}} Selected Framework and Options
     </h4>
     <div *ngIf="visible.options" fxLayout="column" [@expandSection]="true">
-      <md-select
+      <mat-select
         [(ngModel)]="selectedFramework"
         name="framework"
         placeholder="Framework">
-        <md-option
+        <mat-option
           *ngFor="let framework of frameworkList"
           [value]="framework">
           {{frameworks[framework]}}
-        </md-option>
-      </md-select>
+        </mat-option>
+      </mat-select>
       <div class="check-row">
-        <md-checkbox color="primary" [(ngModel)]="jsonFormOptions.returnEmptyFields">
+        <mat-checkbox color="primary" [(ngModel)]="jsonFormOptions.returnEmptyFields">
           Return empty fields?
-        </md-checkbox>
+        </mat-checkbox>
         (default = true)
       </div>
       <div class="check-row">
-        <md-checkbox color="primary" [(ngModel)]="jsonFormOptions.addSubmit">
+        <mat-checkbox color="primary" [(ngModel)]="jsonFormOptions.addSubmit">
           Add submit button?
-        </md-checkbox>
+        </mat-checkbox>
         (default = only add if no layout is defined)
       </div>
       <div class="check-row">
-        <md-checkbox color="primary" [(ngModel)]="jsonFormOptions.formDefaults.feedback">
+        <mat-checkbox color="primary" [(ngModel)]="jsonFormOptions.formDefaults.feedback">
           Show inline fedback?
-        </md-checkbox>
+        </mat-checkbox>
         (default = false)
       </div>
       <div class="check-row">
-        <md-checkbox color="primary" [(ngModel)]="jsonFormOptions.debug">
+        <mat-checkbox color="primary" [(ngModel)]="jsonFormOptions.debug">
           Show debuging information?
-        </md-checkbox>
+        </mat-checkbox>
         (default = false)
       </div>
     </div>
@@ -124,9 +124,9 @@
       style="width:100%; overflow: auto; border: 1px solid black;">
       (loading form specification...)
     </div>
-  </md-card>
+  </mat-card>
 
-  <md-card fxFlex="0 0 calc(50% - 12px)">
+  <mat-card fxFlex="0 0 calc(50% - 12px)">
     <h4 class="defualt-cursor" (click)="toggleVisible('form')">
       {{visible.form ? '▼' : '▶'}} Generated Form
     </h4>
@@ -174,6 +174,6 @@
         <pre [class.data-good]="prettySubmittedFormData !== 'null'">{{prettySubmittedFormData}}</pre>
       </div>
     </div>
-  </md-card>
+  </mat-card>
 
 </div>

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -4,7 +4,15 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { MaterialModule } from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatIconModule,
+  MatMenuModule,
+  MatSelectModule,
+  MatToolbarModule
+} from '@angular/material';
 import { RouterModule } from '@angular/router';
 
 import { JsonSchemaFormModule } from '../../lib/src/json-schema-form.module';
@@ -23,7 +31,8 @@ import { routes } from './demo.routes';
   ],
   imports: [
     BrowserModule, BrowserAnimationsModule, FlexLayoutModule,
-    FormsModule, HttpModule, MaterialModule,
+    FormsModule, HttpModule, MatButtonModule, MatCardModule, MatCheckboxModule,
+    MatIconModule, MatMenuModule, MatSelectModule, MatToolbarModule,
     RouterModule.forRoot(routes), JsonSchemaFormModule
   ],
   providers: [ ],

--- a/src/lib/src/framework-library/material-design-framework/flex-layout-section.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/flex-layout-section.component.ts
@@ -35,20 +35,20 @@ import { Component, Input, OnInit } from '@angular/core';
         [attr.fxFlexFill]="options.fxLayoutAlign"></flex-layout-root-widget>
     </div>
 
-    <md-card *ngIf="containerType === 'fieldset'">
+    <mat-card *ngIf="containerType === 'fieldset'">
       <fieldset
         [class]="options?.htmlClass"
         [class.expandable]="options?.expandable && !expanded"
         [class.expanded]="options?.expandable && expanded"
         [disabled]="options?.readonly">
-        <md-card-header>
+        <mat-card-header>
           <legend
             [class]="options?.labelHtmlClass"
             [style.display]="legendDisplay()"
             [innerHTML]="options?.title"
             (click)="expand()"></legend>
-        </md-card-header>
-        <md-card-content>
+        </mat-card-header>
+        <mat-card-content>
           <flex-layout-root-widget
             *ngIf="expanded"
             [formID]="formID"
@@ -70,9 +70,9 @@ import { Component, Input, OnInit } from '@angular/core';
             [fxLayoutGap]="options.fxLayoutGap"
             [fxLayoutAlign]="options.fxLayoutAlign"
             [attr.fxFlexFill]="options.fxLayoutAlign"></flex-layout-root-widget>
-        </md-card-content>
+        </mat-card-content>
       </fieldset>
-    </md-card>`,
+    </mat-card>`,
   styles: [`
     .expandable > legend:before { content: '▶'; padding-right: .3em; }
     .expanded > legend:before { content: '▼'; padding-right: .2em; }

--- a/src/lib/src/framework-library/material-design-framework/material-add-reference.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-add-reference.component.ts
@@ -7,7 +7,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
   selector: 'material-add-reference-widget',
   template: `
     <section [class]="options?.htmlClass" align="end">
-      <button md-raised-button *ngIf="showAddButton"
+      <button mat-raised-button *ngIf="showAddButton"
         [color]="options?.color || 'accent'"
         [disabled]="options?.readonly"
         (click)="addItem($event)">

--- a/src/lib/src/framework-library/material-design-framework/material-button-group.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-button-group.component.ts
@@ -14,20 +14,20 @@ import { buildTitleMap } from '../../shared';
         [style.display]="options?.notitle ? 'none' : ''"
         [innerHTML]="options?.title"></label>
     </div>
-    <md-button-toggle-group
+    <mat-button-toggle-group
       [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
       [attr.readonly]="options?.readonly ? 'readonly' : null"
       [attr.required]="options?.required"
       [disabled]="controlDisabled"
       [name]="controlName"
       [value]="controlValue">
-      <md-button-toggle *ngFor="let radioItem of radiosList"
+      <mat-button-toggle *ngFor="let radioItem of radiosList"
         [id]="'control' + layoutNode?._id + '/' + radioItem?.name"
         [value]="radioItem?.value"
         (click)="updateValue(radioItem?.value)">
         <span [innerHTML]="radioItem?.name"></span>
-      </md-button-toggle>
-    </md-button-toggle-group>`,
+      </mat-button-toggle>
+    </mat-button-toggle-group>`,
 })
 export class MaterialButtonGroupComponent implements OnInit {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-button.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-button.component.ts
@@ -7,7 +7,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
   selector: 'material-button-widget',
   template: `
     <div class="button-row" [class]="options?.htmlClass">
-      <button md-raised-button
+      <button mat-raised-button
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [color]="options?.color || 'primary'"
@@ -17,7 +17,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
         [type]="layoutNode?.type"
         [value]="controlValue"
         (click)="updateValue($event)">
-        <md-icon *ngIf="options?.icon" class="md-24">{{options?.icon}}</md-icon>
+        <mat-icon *ngIf="options?.icon" class="md-24">{{options?.icon}}</mat-icon>
         <span *ngIf="options?.title" [innerHTML]="options?.title"></span>
       </button>
     </div>`,

--- a/src/lib/src/framework-library/material-design-framework/material-card.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-card.component.ts
@@ -5,28 +5,28 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
 @Component({
   selector: 'material-card-widget',
   template: `
-    <md-card
+    <mat-card
       [attr.disabled]="options?.readonly"
       [class]="options?.htmlClass"
       [class.expandable]="options?.expandable && !expanded"
       [class.expanded]="options?.expandable && expanded">
-      <md-card-header *ngIf="options?.title || options?.description"
+      <mat-card-header *ngIf="options?.title || options?.description"
         [class]="options?.labelHtmlClass"
         (click)="expand()">
-        <md-card-title *ngIf="options?.title"
+        <mat-card-title *ngIf="options?.title"
           [style.display]="options?.notitle ? 'none' : ''"
-          [innerHTML]="options?.title"></md-card-title>
-        <md-card-subtitle *ngIf="options?.description">{{options?.description}}</md-card-subtitle>
-      </md-card-header>
-      <md-card-content>
+          [innerHTML]="options?.title"></mat-card-title>
+        <mat-card-subtitle *ngIf="options?.description">{{options?.description}}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
         <root-widget *ngIf="expanded"
           [formID]="formID"
           [layout]="layoutNode.items"
           [dataIndex]="dataIndex"
           [layoutIndex]="layoutIndex"
           [isOrderable]="options?.orderable"></root-widget>
-      </md-card-content>
-    </md-card>`,
+      </mat-card-content>
+    </mat-card>`,
   styles: [`
     .expandable > legend:before { content: '▶'; padding-right: .3em; }
     .expanded > legend:before { content: '▼'; padding-right: .2em; }

--- a/src/lib/src/framework-library/material-design-framework/material-checkbox.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-checkbox.component.ts
@@ -6,7 +6,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
 @Component({
   selector: 'material-checkbox-widget',
   template: `
-    <md-checkbox
+    <mat-checkbox
       align="left"
       [color]="options?.color || 'primary'"
       [disabled]="controlDisabled || options?.readonly"
@@ -18,7 +18,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
         class="checkbox-name"
         [style.display]="options?.notitle ? 'none' : ''"
         [innerHTML]="options?.title"></span>
-    </md-checkbox>`,
+    </mat-checkbox>`,
   styles: [` .checkbox-name { white-space: nowrap; } `],
 })
 export class MaterialCheckboxComponent implements OnInit {

--- a/src/lib/src/framework-library/material-design-framework/material-checkboxes.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-checkboxes.component.ts
@@ -10,7 +10,7 @@ import { buildFormGroup, buildTitleMap, JsonPointer } from '../../shared';
 @Component({
   selector: 'material-checkboxes-widget',
   template: `
-    <md-checkbox type="checkbox"
+    <mat-checkbox type="checkbox"
       [color]="options?.color || 'primary'"
       [disabled]="controlDisabled || options?.readonly"
       [name]="options?.name"
@@ -18,7 +18,7 @@ import { buildFormGroup, buildTitleMap, JsonPointer } from '../../shared';
       [indeterminate]="someChecked"
       (change)="updateAllValues($event)">
       <span class="checkbox-name" [innerHTML]="options?.name"></span>
-    </md-checkbox>
+    </mat-checkbox>
     <label *ngIf="options?.title"
       [class]="options?.labelHtmlClass"
       [style.display]="options?.notitle ? 'none' : ''"
@@ -26,14 +26,14 @@ import { buildFormGroup, buildTitleMap, JsonPointer } from '../../shared';
     <ul class="checkbox-list" [class.horizontal-list]="horizontalList">
       <li *ngFor="let checkboxItem of checkboxList"
         [class]="options?.htmlClass">
-        <md-checkbox type="checkbox"
+        <mat-checkbox type="checkbox"
           [(ngModel)]="checkboxItem.checked"
           [color]="options?.color || 'primary'"
           [disabled]="controlDisabled || options?.readonly"
           [name]="checkboxItem?.name"
           (change)="updateValue($event)">
           <span class="checkbox-name" [innerHTML]="checkboxItem?.name"></span>
-        </md-checkbox>
+        </mat-checkbox>
       </li>
     </ul>`,
   styles: [`

--- a/src/lib/src/framework-library/material-design-framework/material-datepicker.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-datepicker.component.ts
@@ -7,15 +7,15 @@ import { dateToString, stringToDate } from '../../shared';
 @Component({
   selector: 'material-datepicker-widget',
   template: `
-    <md-form-field [style.width]="'100%'">
-      <input mdInput #inputControl
+    <mat-form-field [style.width]="'100%'">
+      <input matInput #inputControl
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [disabled]="controlDisabled"
         [id]="'control' + layoutNode?._id"
         [max]="options?.maximum"
-        [mdDatepicker]="picker"
+        [matDatepicker]="picker"
         [min]="options?.minimum"
         [name]="controlName"
         [placeholder]="options?.title"
@@ -24,17 +24,17 @@ import { dateToString, stringToDate } from '../../shared';
         [value]="dateValue"
         (change)="updateValue(inputControl.value)">
       <span *ngIf="options?.fieldAddonLeft"
-        md-prefix>{{options?.fieldAddonLeft}}</span>
+        mat-prefix>{{options?.fieldAddonLeft}}</span>
       <span *ngIf="options?.fieldAddonRight"
-        md-suffix>{{options?.fieldAddonRight}}</span>
-      <md-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
-        align="end">{{options?.description}}</md-hint>
-      <md-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
-        align="end">{{options?.placeholder}}</md-hint>
-      <md-datepicker-toggle mdSuffix [for]="picker"></md-datepicker-toggle>
-    </md-form-field>
-    <md-datepicker #picker
-      (selectedChanged)="updateValue($event)"></md-datepicker>`,
+        mat-suffix>{{options?.fieldAddonRight}}</span>
+      <mat-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
+        align="end">{{options?.description}}</mat-hint>
+      <mat-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
+        align="end">{{options?.placeholder}}</mat-hint>
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    </mat-form-field>
+    <mat-datepicker #picker
+      (selectedChanged)="updateValue($event)"></mat-datepicker>`,
 })
 export class MaterialDatepickerComponent implements OnInit, OnChanges {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
@@ -4,9 +4,16 @@ import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
-  MaterialModule, MdDatepickerModule, MdNativeDateModule
+  MatAutocompleteModule, MatButtonModule, MatButtonToggleModule,
+  MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule,
+  MatDialogModule, MatExpansionModule, MatFormFieldModule, MatGridListModule,
+  MatIconModule, MatInputModule, MatListModule, MatMenuModule,
+  MatNativeDateModule, MatPaginatorModule, MatProgressBarModule,
+  MatProgressSpinnerModule, MatRadioModule, MatSelectModule, MatSidenavModule,
+  MatSliderModule, MatSlideToggleModule, MatSnackBarModule, MatSortModule,
+  MatTableModule, MatTabsModule, MatToolbarModule, MatTooltipModule,
+  MatStepperModule,
 } from '@angular/material';
-
 import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
 import { JsonSchemaFormService } from '../../json-schema-form.service';
 
@@ -14,9 +21,17 @@ import { MATERIAL_DESIGN_COMPONENTS } from './index';
 
 @NgModule({
   imports: [
-    CommonModule, FlexLayoutModule,
-    FormsModule, ReactiveFormsModule, MaterialModule,
-    MdDatepickerModule, MdNativeDateModule, WidgetLibraryModule
+    CommonModule, FlexLayoutModule, FormsModule, ReactiveFormsModule,
+    MatAutocompleteModule, MatButtonModule, MatButtonToggleModule,
+    MatCardModule, MatCheckboxModule, MatChipsModule, MatTableModule,
+    MatDatepickerModule, MatDialogModule, MatExpansionModule,
+    MatFormFieldModule, MatGridListModule, MatIconModule, MatInputModule,
+    MatListModule, MatMenuModule, MatPaginatorModule, MatProgressBarModule,
+    MatProgressSpinnerModule, MatRadioModule, MatSelectModule, MatSidenavModule,
+    MatSlideToggleModule, MatSliderModule, MatSnackBarModule, MatSortModule,
+    MatStepperModule, MatTabsModule, MatToolbarModule, MatTooltipModule,
+    MatNativeDateModule,
+    WidgetLibraryModule
   ],
   declarations:    [ ...MATERIAL_DESIGN_COMPONENTS ],
   exports:         [ ...MATERIAL_DESIGN_COMPONENTS ],

--- a/src/lib/src/framework-library/material-design-framework/material-input.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-input.component.ts
@@ -6,10 +6,10 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
 @Component({
   selector: 'material-input-widget',
   template: `
-    <md-form-field
+    <mat-form-field
       [floatPlaceholder]="options?.floatPlaceholder || (options?.notitle ? 'never' : 'auto')"
       [style.width]="'100%'">
-      <input mdInput #inputControl
+      <input matInput #inputControl
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
         [attr.maxlength]="options?.maxLength"
@@ -26,12 +26,12 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
         [value]="controlValue"
         (input)="updateValue($event)">
       <span *ngIf="options?.fieldAddonLeft"
-        md-prefix>{{options?.fieldAddonLeft}}</span>
+        mat-prefix>{{options?.fieldAddonLeft}}</span>
       <span *ngIf="options?.fieldAddonRight"
-        md-suffix>{{options?.fieldAddonRight}}</span>
-      <md-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
-        align="end">{{options?.description}}</md-hint>
-    </md-form-field>`,
+        mat-suffix>{{options?.fieldAddonRight}}</span>
+      <mat-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
+        align="end">{{options?.description}}</mat-hint>
+    </mat-form-field>`,
 })
 export class MaterialInputComponent implements OnInit {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-number.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-number.component.ts
@@ -7,8 +7,8 @@ import { getControl, inArray, isDefined } from '../../shared';
 @Component({
   selector: 'material-number-widget',
   template: `
-    <md-form-field [style.width]="'100%'">
-      <input mdInput #inputControl
+    <mat-form-field [style.width]="'100%'">
+      <input matInput #inputControl
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.max]="options?.maximum"
         [attr.min]="options?.minimum"
@@ -25,15 +25,15 @@ import { getControl, inArray, isDefined } from '../../shared';
         [value]="controlValue"
         (input)="updateValue($event)">
       <span *ngIf="options?.fieldAddonLeft"
-        md-prefix>{{options?.fieldAddonLeft}}</span>
+        mat-prefix>{{options?.fieldAddonLeft}}</span>
       <span *ngIf="options?.fieldAddonRight"
-        md-suffix>{{options?.fieldAddonRight}}</span>
-      <md-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
-        align="end">{{options?.description}}</md-hint>
-      <md-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
-        align="end">{{options?.placeholder}}</md-hint>
+        mat-suffix>{{options?.fieldAddonRight}}</span>
+      <mat-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
+        align="end">{{options?.description}}</mat-hint>
+      <mat-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
+        align="end">{{options?.placeholder}}</mat-hint>
       {{layoutNode?.type === 'range' ? controlValue : ''}}
-    </md-form-field>`,
+    </mat-form-field>`,
 })
 export class MaterialNumberComponent implements OnInit {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-radios.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-radios.component.ts
@@ -14,7 +14,7 @@ import { buildTitleMap } from '../../shared';
         [style.display]="options?.notitle ? 'none' : ''"
         [innerHTML]="options?.title"></label>
     </div>
-    <md-radio-group
+    <mat-radio-group
       [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
       [attr.readonly]="options?.readonly ? 'readonly' : null"
       [attr.required]="options?.required"
@@ -22,16 +22,16 @@ import { buildTitleMap } from '../../shared';
       [disabled]="controlDisabled"
       [name]="controlName"
       [value]="controlValue">
-      <md-radio-button *ngFor="let radioItem of radiosList"
+      <mat-radio-button *ngFor="let radioItem of radiosList"
         [id]="'control' + layoutNode?._id + '/' + radioItem?.name"
         [value]="radioItem?.value"
         (click)="updateValue(radioItem?.value)">
         <span [innerHTML]="radioItem?.name"></span>
-      </md-radio-button>
-    </md-radio-group>`,
+      </mat-radio-button>
+    </mat-radio-group>`,
   styles: [`
-    md-radio-group { display: inline-flex; }
-    md-radio-button { margin: 2px; }
+    mat-radio-group { display: inline-flex; }
+    mat-radio-button { margin: 2px; }
   `]
 })
 export class MaterialRadiosComponent implements OnInit {

--- a/src/lib/src/framework-library/material-design-framework/material-select.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-select.component.ts
@@ -7,13 +7,15 @@ import { buildTitleMap } from '../../shared';
 @Component({
   selector: 'material-select-widget',
   template: `
-    <section [style.width]="'100%'" [class]="options?.htmlClass || null">
-      <md-select #inputControl
+    <mat-form-field
+      [floatPlaceholder]="options?.floatPlaceholder || (options?.notitle ? 'never' : 'auto')"
+      [style.width]="'100%'"
+      [class]="options?.htmlClass || null">
+      <mat-select #inputControl
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.name]="controlName"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [disabled]="controlDisabled"
-        [floatPlaceholder]="options?.floatPlaceholder || (options?.notitle ? 'never' : 'auto')"
         [id]="'control' + layoutNode?._id"
         [multiple]="options?.multiple"
         [placeholder]="options?.notitle ? options?.placeholder : options?.title"
@@ -21,13 +23,13 @@ import { buildTitleMap } from '../../shared';
         [style.width]="'100%'"
         [value]="controlValue"
         (change)="updateValue($event)">
-        <md-option *ngFor="let selectItem of selectList"
+        <mat-option *ngFor="let selectItem of selectList"
           [attr.selected]="selectItem.value === controlValue"
           [value]="selectItem.value">
         <span [innerHTML]="selectItem?.name"></span>
-        </md-option>
-      </md-select>
-    </section>`,
+        </mat-option>
+      </mat-select>
+    </mat-form-field>`,
 })
 export class MaterialSelectComponent implements OnInit {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-slider.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-slider.component.ts
@@ -7,7 +7,7 @@ import { getControl, inArray, isDefined } from '../../shared';
 @Component({
   selector: 'material-slider-widget',
   template: `
-    <md-slider #inputControl
+    <mat-slider #inputControl
       [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
       [disabled]="controlDisabled"
       [id]="'control' + layoutNode?._id"
@@ -17,7 +17,7 @@ import { getControl, inArray, isDefined } from '../../shared';
       [style.width]="'100%'"
       [thumb-label]="true"
       [value]="controlValue"
-      (change)="updateValue($event)"></md-slider>`,
+      (change)="updateValue($event)"></mat-slider>`,
 })
 export class MaterialSliderComponent implements OnInit {
   formControl: AbstractControl;

--- a/src/lib/src/framework-library/material-design-framework/material-tabs.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-tabs.component.ts
@@ -6,11 +6,11 @@ import { JsonPointer } from '../../shared';
 @Component({
   selector: 'material-tabs-widget',
   template: `
-    <nav md-tab-nav-bar
+    <nav mat-tab-nav-bar
       [attr.aria-label]="options?.label || options?.title"
       [style.width]="'100%'">
         <a *ngFor="let item of layoutNode?.items; let i = index"
-          md-tab-link
+          mat-tab-link
           [active]="selectedItem === i"
           (click)="select(i)">
           <span *ngIf="showAddTab || item.type !== '$ref'"

--- a/src/lib/src/framework-library/material-design-framework/material-textarea.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-textarea.component.ts
@@ -6,8 +6,8 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
 @Component({
   selector: 'material-textarea-widget',
   template: `
-    <md-form-field [style.width]="'100%'">
-      <textarea mdInput #inputControl
+    <mat-form-field [style.width]="'100%'">
+      <textarea matInput #inputControl
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.list]="'control' + layoutNode?._id + 'Autocomplete'"
         [attr.maxlength]="options?.maxLength"
@@ -23,14 +23,14 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
         [value]="controlValue"
         (input)="updateValue($event)"></textarea>
       <span *ngIf="options?.fieldAddonLeft"
-        md-prefix>{{options?.fieldAddonLeft}}</span>
+        mat-prefix>{{options?.fieldAddonLeft}}</span>
       <span *ngIf="options?.fieldAddonRight"
-        md-suffix>{{options?.fieldAddonRight}}</span>
-      <md-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
-        align="end">{{options?.description}}</md-hint>
-      <md-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
-        align="end">{{options?.placeholder}}</md-hint>
-    </md-form-field>`,
+        mat-suffix>{{options?.fieldAddonRight}}</span>
+      <mat-hint *ngIf="options?.description && !options?.placeholder && formControl?.dirty"
+        align="end">{{options?.description}}</mat-hint>
+      <mat-hint *ngIf="!options?.description && options?.placeholder && !formControl?.dirty"
+        align="end">{{options?.placeholder}}</mat-hint>
+    </mat-form-field>`,
 })
 export class MaterialTextareaComponent implements OnInit {
   formControl: AbstractControl;


### PR DESCRIPTION
The latest version of Angular Material beta12 removed the deprecated MaterialModule in favor of importing individual modules. Also the md- prefix has been changed to mat-.

I verified the demo still works locally for several of the schemas for Material, but no other testing.