### PR TITLE
Removing previously compiled schemas allows live previews and generat…

### DIFF
--- a/src/lib/src/json-schema-form.service.ts
+++ b/src/lib/src/json-schema-form.service.ts
@@ -289,6 +289,7 @@ export class JsonSchemaFormService {
         this.schema['ui:order'] = this.schema.properties['ui:order'];
         delete this.schema.properties['ui:order'];
       }
+      this.ajv.removeSchema(this.schema);
       this.validateFormData = this.ajv.compile(this.schema);
     }
   }


### PR DESCRIPTION
Add support for form generation use cases in which the form gets regenerated often: the schema content is bound with a code editor and form previews are generated after changes are made.
This can only happen if the schema gets removed from the ajv cache, otherwise a fatal error is thrown. 