### PR TITLE
Allow passing key-value pair to buildRemoteError so {{key}} style err…

### DIFF
--- a/src/lib/src/json-schema-form.service.ts
+++ b/src/lib/src/json-schema-form.service.ts
@@ -26,7 +26,7 @@ export interface TitleMapItem {
   name?: string, value?: any, checked?: boolean, group?: string, items?: TitleMapItem[]
 };
 export interface ErrorMessages {
-  [control_name: string]: { message: string|Function, code: string }[]
+  [control_name: string]: { message: string|Function|Object, code: string }[]
 };
 
 @Injectable()


### PR DESCRIPTION
Allow passing key-value pair to buildRemoteError so {{key}} style errors can be buildRemoted

## PR Type
What changes does this PR include (check all that apply)?
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:
```

## Related issue / current behavior
Currently when using buildRemoteError you can only pass an object of type function or string, which does not allow you to buildRemoteError a field that has an errorMessages value like "something {{key}} happened"

## New behavior
Just allow an object like this to be passed in
{message: {propertyToReplace: "replacement"}, code: err.field}


## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```
