### PR TITLE
Small bug fixes + translation of default error messages

### DIFF
--- a/src/demo/app/demo.component.html
+++ b/src/demo/app/demo.component.html
@@ -77,7 +77,6 @@
       <mat-form-field>
         <mat-select
           [(ngModel)]="selectedFramework"
-          (change)="loadSelectedFramework()"
           name="framework"
           placeholder="Framework">
           <mat-option

--- a/src/demo/app/demo.component.html
+++ b/src/demo/app/demo.component.html
@@ -70,19 +70,33 @@
   fxLayout.lt-sm="column" fxLayoutAlign.lt-sm="flex-start center">
 
   <mat-card fxFlex="0 0 calc(50% - 12px)">
-    <h4 class="defualt-cursor" (click)="toggleVisible('options')">
+    <h4 class="default-cursor" (click)="toggleVisible('options')">
       {{visible.options ? '▼' : '▶'}} Selected Framework and Options
     </h4>
     <div *ngIf="visible.options" fxLayout="column" [@expandSection]="true">
       <mat-form-field>
         <mat-select
           [(ngModel)]="selectedFramework"
+          (change)="loadSelectedFramework()"
           name="framework"
           placeholder="Framework">
           <mat-option
             *ngFor="let framework of frameworkList"
             [value]="framework">
             {{frameworks[framework]}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-select
+          [(ngModel)]="selectedLanguage"
+          (change)="loadSelectedLanguage()"
+          name="language"
+          placeholder="Language">
+          <mat-option
+            *ngFor="let language of languageList"
+            [value]="language">
+            {{languages[language]}}
           </mat-option>
         </mat-select>
       </mat-form-field>
@@ -112,7 +126,7 @@
       </div>
     </div>
     <hr>
-    <h4 class="defualt-cursor" (click)="toggleVisible('schema')">
+    <h4 class="default-cursor" (click)="toggleVisible('schema')">
       {{visible.schema ? '▼' : '▶'}} Input JSON Schema and Form Layout
     </h4>
     <div *ngIf="visible.schema" [@expandSection]="true"
@@ -128,7 +142,7 @@
   </mat-card>
 
   <mat-card fxFlex="0 0 calc(50% - 12px)">
-    <h4 class="defualt-cursor" (click)="toggleVisible('form')">
+    <h4 class="default-cursor" (click)="toggleVisible('form')">
       {{visible.form ? '▼' : '▶'}} Generated Form
     </h4>
     <div *ngIf="visible.form" class="json-schema-form" [@expandSection]="true">
@@ -149,7 +163,7 @@
 
     </div>
     <hr>
-    <h4 class="defualt-cursor" (click)="toggleVisible('output')">
+    <h4 class="default-cursor" (click)="toggleVisible('output')">
       {{visible.output ? '▼' : '▶'}} Form Output
     </h4>
     <div *ngIf="visible.output" fxLayout="column" [@expandSection]="true">

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -189,16 +189,6 @@ export class DemoComponent implements OnInit {
       });
   }
 
-  loadSelectedFramework() {
-    console.log('loadSelectedFramework');
-    window.location.href =
-      '/?set=' + this.selectedSet +
-      '&example=' + this.selectedExample +
-      '&framework=' + this.selectedFramework +
-      '&language=' + this.selectedLanguage;
-  //  this.generateForm(this.jsonFormSchema);
-  }
-
   loadSelectedLanguage() {
     console.log('loadSelectedLanguage');
     window.location.href =

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -27,6 +27,11 @@ import { JsonPointer } from '../../lib/src/shared';
 })
 export class DemoComponent implements OnInit {
   examples: any = Examples;
+  languageList: any = ['en', 'fr'];
+  languages: any = {
+    'en': 'English',
+    'fr': 'French',
+  };
   frameworkList: any = ['material-design', 'bootstrap-3', 'bootstrap-4', 'no-framework'];
   frameworks: any = {
     'material-design': 'Material Design',
@@ -39,6 +44,7 @@ export class DemoComponent implements OnInit {
   selectedExample = 'ng-jsf-flex-layout';
   selectedExampleName = 'Flexbox layout';
   selectedFramework = 'material-design';
+  selectedLanguage = 'en';
   visible: { [item: string]: boolean } = {
     options: true,
     schema: true,
@@ -97,6 +103,9 @@ export class DemoComponent implements OnInit {
         }
         if (params['framework']) {
           this.selectedFramework = params['framework'];
+        }
+        if (params['language']) {
+          this.selectedLanguage = params['language'];
         }
         this.loadSelectedExample();
       }
@@ -163,7 +172,8 @@ export class DemoComponent implements OnInit {
       this.router.navigateByUrl(
         '/?set=' + selectedSet +
         '&example=' + selectedExample +
-        '&framework=' + this.selectedFramework
+        '&framework=' + this.selectedFramework +
+        '&language=' + this.selectedLanguage
       );
       this.liveFormData = {};
       this.submittedFormData = null;
@@ -179,13 +189,24 @@ export class DemoComponent implements OnInit {
       });
   }
 
-  loadSelectedFramework(selectedFramework: string) {
-    this.router.navigateByUrl(
+  loadSelectedFramework() {
+    console.log('loadSelectedFramework');
+    window.location.href =
       '/?set=' + this.selectedSet +
       '&example=' + this.selectedExample +
-      '&framework=' + selectedFramework
-    );
-    this.generateForm(this.jsonFormSchema);
+      '&framework=' + this.selectedFramework +
+      '&language=' + this.selectedLanguage;
+  //  this.generateForm(this.jsonFormSchema);
+  }
+
+  loadSelectedLanguage() {
+    console.log('loadSelectedLanguage');
+    window.location.href =
+      '/?set=' + this.selectedSet +
+      '&example=' + this.selectedExample +
+      '&framework=' + this.selectedFramework +
+      '&language=' + this.selectedLanguage;
+   // this.generateForm(this.jsonFormSchema);
   }
 
   // Display the form entered by the user

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -11,6 +11,8 @@ import {
 import { RouterModule } from '@angular/router';
 
 import { JsonSchemaFormModule } from '../../lib/src/json-schema-form.module';
+import { JsonSchemaFormIntl } from '../../lib/src/json-schema-form-intl';
+import { JsonSchemaFormIntlFr } from '../../lib/src/i18n/json-schema-form-intl-fr';
 // To include JsonSchemaFormModule after downloading from NPM, use this instead:
 // import { JsonSchemaFormModule } from 'angular2-json-schema-form';
 
@@ -19,6 +21,10 @@ import { DemoComponent } from './demo.component';
 import { DemoRootComponent } from './demo-root.component';
 
 import { routes } from './demo.routes';
+import { ActivatedRoute, Router } from '@angular/router';
+
+
+let language = '';
 
 @NgModule({
   declarations: [ AceEditorDirective, DemoComponent, DemoRootComponent ],
@@ -27,6 +33,28 @@ import { routes } from './demo.routes';
     HttpClientModule, MatButtonModule, MatCardModule, MatCheckboxModule,
     MatIconModule, MatMenuModule, MatSelectModule, MatToolbarModule,
     RouterModule.forRoot(routes), JsonSchemaFormModule
+  ],
+  providers: [
+    /*
+    {provide: JsonSchemaFormIntl, useClass: JsonSchemaFormIntlFr
+    },
+    */
+    {
+        provide: JsonSchemaFormIntl,  useFactory:
+           function(route: ActivatedRoute) {
+              route.queryParams.subscribe(
+                params => {
+                  language = params['language'];
+                });
+                switch (language) {
+                  case 'fr':
+                    return new JsonSchemaFormIntlFr();
+                  default:
+                    return new JsonSchemaFormIntl();
+                }
+           },
+           deps: [ActivatedRoute]
+    }
   ],
   bootstrap: [ DemoRootComponent ]
 })

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -23,6 +23,18 @@ import { DemoRootComponent } from './demo-root.component';
 import { routes } from './demo.routes';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { Framework } from '../../lib/src/framework-library/framework';
+
+import { FrameworkNoFramework } from '../../lib/src/framework-library/framework.no-framework';
+
+import { Bootstrap3FrameworkModule } from '../../lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.module';
+import { FrameworkBootstrap3 } from '../../lib/src/framework-library/framework.bootstrap3';
+
+import { Bootstrap4FrameworkModule } from '../../lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.module';
+import { FrameworkBootstrap4 } from '../../lib/src/framework-library/framework.bootstrap4';
+
+import { MaterialDesignFrameworkModule } from '../../lib/src/framework-library/material-design-framework/material-design-framework.module';
+import { FrameworkMaterialDesign } from '../../lib/src/framework-library/framework.material-design';
 
 let language = '';
 
@@ -32,13 +44,12 @@ let language = '';
     BrowserModule, BrowserAnimationsModule, FlexLayoutModule, FormsModule,
     HttpClientModule, MatButtonModule, MatCardModule, MatCheckboxModule,
     MatIconModule, MatMenuModule, MatSelectModule, MatToolbarModule,
-    RouterModule.forRoot(routes), JsonSchemaFormModule
+    RouterModule.forRoot(routes), JsonSchemaFormModule,
+    Bootstrap3FrameworkModule,
+    Bootstrap4FrameworkModule,
+    MaterialDesignFrameworkModule
   ],
   providers: [
-    /*
-    {provide: JsonSchemaFormIntl, useClass: JsonSchemaFormIntlFr
-    },
-    */
     {
         provide: JsonSchemaFormIntl,  useFactory:
            function(route: ActivatedRoute) {
@@ -54,7 +65,11 @@ let language = '';
                 }
            },
            deps: [ActivatedRoute]
-    }
+    },
+    { provide: Framework, useClass: FrameworkNoFramework, multi: true },
+    { provide: Framework, useClass: FrameworkBootstrap3, multi: true },
+    { provide: Framework, useClass: FrameworkBootstrap4, multi: true },
+    { provide: Framework, useClass: FrameworkMaterialDesign, multi: true }
   ],
   bootstrap: [ DemoRootComponent ]
 })

--- a/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.component.ts
+++ b/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.component.ts
@@ -159,12 +159,14 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
 
       this.options.htmlClass =
         addClasses(this.options.htmlClass, 'schema-form-' + this.layoutNode.type);
-      this.options.htmlClass =
-        this.layoutNode.type === 'array' ?
-          addClasses(this.options.htmlClass, 'list-group') :
-        this.layoutNode.arrayItem && this.layoutNode.type !== '$ref' ?
-          addClasses(this.options.htmlClass, 'list-group-item') :
-          addClasses(this.options.htmlClass, 'form-group');
+      if (this.layoutNode.type !== 'flex')  {
+          this.options.htmlClass =
+            this.layoutNode.type === 'array' ?
+              addClasses(this.options.htmlClass, 'list-group') :
+            this.layoutNode.arrayItem && this.layoutNode.type !== '$ref' ?
+              addClasses(this.options.htmlClass, 'list-group-item') :
+              addClasses(this.options.htmlClass, 'form-group');
+      }
       this.widgetOptions.htmlClass = '';
       this.options.labelHtmlClass =
         addClasses(this.options.labelHtmlClass, 'control-label');

--- a/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.component.ts
+++ b/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.component.ts
@@ -289,6 +289,9 @@ export class Bootstrap3FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
+      case 'fieldset':
+        this.widgetOptions.title = this.options.title;
+        return null;
       default:
         this.widgetOptions.title = null;
         return this.jsf.setItemTitle(this);

--- a/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.component.ts
+++ b/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.component.ts
@@ -287,6 +287,9 @@ export class Bootstrap4FrameworkComponent implements OnInit, OnChanges {
         this.widgetOptions.expandable = true;
         this.widgetOptions.title = 'Authentication settings';
         return null;
+      case 'fieldset':
+        this.widgetOptions.title = this.options.title;
+        return null;
       default:
         this.widgetOptions.title = null;
         return this.jsf.setItemTitle(this);

--- a/src/lib/src/framework-library/framework-library.module.ts
+++ b/src/lib/src/framework-library/framework-library.module.ts
@@ -5,22 +5,15 @@ import { WidgetLibraryModule } from '../widget-library/widget-library.module';
 import { WidgetLibraryService } from '../widget-library/widget-library.service';
 
 import { FrameworkLibraryService } from './framework-library.service';
-
-import { Bootstrap3FrameworkModule } from './bootstrap-3-framework/bootstrap-3-framework.module';
-import { MaterialDesignFrameworkModule } from './material-design-framework/material-design-framework.module';
-
 import { NoFrameworkComponent } from './no-framework.component';
-import { Bootstrap4FrameworkModule } from './bootstrap-4-framework/bootstrap-4-framework.module';
 
 @NgModule({
   imports:         [
     CommonModule, WidgetLibraryModule,
-    Bootstrap3FrameworkModule, MaterialDesignFrameworkModule, Bootstrap4FrameworkModule
   ],
   declarations:    [ NoFrameworkComponent ],
   exports:         [
     NoFrameworkComponent,
-    Bootstrap3FrameworkModule, MaterialDesignFrameworkModule, Bootstrap4FrameworkModule
   ],
   entryComponents: [ NoFrameworkComponent ],
   providers:       [ WidgetLibraryService, FrameworkLibraryService ]

--- a/src/lib/src/framework-library/framework-library.service.ts
+++ b/src/lib/src/framework-library/framework-library.service.ts
@@ -3,39 +3,9 @@ import { Inject, Injectable } from '@angular/core';
 import { WidgetLibraryService } from '../widget-library/widget-library.service';
 import { hasOwn } from '../shared/utility.functions';
 
-// No framework - plain HTML controls (styles from form layout only)
-import { NoFrameworkComponent } from './no-framework.component';
+import { Framework } from './framework';
 
-// Bootstrap 3 Framework
-// https://github.com/valor-software/ng2-bootstrap
-import { Bootstrap3FrameworkComponent } from './bootstrap-3-framework/bootstrap-3-framework.component';
-
-// Bootstrap 4 Framework
-// https://github.com/ng-bootstrap/ng-bootstrap
-import { Bootstrap4FrameworkComponent } from './bootstrap-4-framework/bootstrap-4-framework.component';
-
-// Material Design Framework
-// https://github.com/angular/material2
-import { FlexLayoutRootComponent } from './material-design-framework/flex-layout-root.component';
-import { FlexLayoutSectionComponent } from './material-design-framework/flex-layout-section.component';
-import { MaterialAddReferenceComponent } from './material-design-framework/material-add-reference.component';
-import { MaterialOneOfComponent } from './material-design-framework/material-one-of.component';
-import { MaterialButtonComponent } from './material-design-framework/material-button.component';
-import { MaterialButtonGroupComponent } from './material-design-framework/material-button-group.component';
-import { MaterialCheckboxComponent } from './material-design-framework/material-checkbox.component';
-import { MaterialCheckboxesComponent } from './material-design-framework/material-checkboxes.component';
-import { MaterialChipListComponent } from './material-design-framework/material-chip-list.component';
-import { MaterialDatepickerComponent } from './material-design-framework/material-datepicker.component';
-import { MaterialFileComponent } from './material-design-framework/material-file.component';
-import { MaterialInputComponent } from './material-design-framework/material-input.component';
-import { MaterialNumberComponent } from './material-design-framework/material-number.component';
-import { MaterialRadiosComponent } from './material-design-framework/material-radios.component';
-import { MaterialSelectComponent } from './material-design-framework/material-select.component';
-import { MaterialSliderComponent } from './material-design-framework/material-slider.component';
-import { MaterialStepperComponent } from './material-design-framework/material-stepper.component';
-import { MaterialTabsComponent } from './material-design-framework/material-tabs.component';
-import { MaterialTextareaComponent } from './material-design-framework/material-textarea.component';
-import { MaterialDesignFrameworkComponent } from './material-design-framework/material-design-framework.component';
+import { FrameworkNoFramework } from './framework.no-framework';
 
 // Possible future frameworks:
 // - Foundation 6:
@@ -45,17 +15,6 @@ import { MaterialDesignFrameworkComponent } from './material-design-framework/ma
 //   https://github.com/edcarroll/ng2-semantic-ui
 //   https://github.com/vladotesanovic/ngSemantic
 
-export interface Framework {
-  framework: any,
-  widgets?: { [key: string]: any },
-  stylesheets?: string[],
-  scripts?: string[]
-};
-
-export interface FrameworkLibrary {
-  [key: string]: Framework
-};
-
 @Injectable()
 export class FrameworkLibraryService {
   activeFramework: Framework = null;
@@ -63,79 +22,16 @@ export class FrameworkLibraryService {
   scripts: HTMLScriptElement[];
   loadExternalAssets = false;
   defaultFramework = 'no-framework';
-  frameworkLibrary: FrameworkLibrary = {
-    'no-framework': {
-      framework: NoFrameworkComponent
-    },
-    'material-design': {
-      framework: MaterialDesignFrameworkComponent,
-      widgets: {
-        'root':            FlexLayoutRootComponent,
-        'section':         FlexLayoutSectionComponent,
-        '$ref':            MaterialAddReferenceComponent,
-        'button':          MaterialButtonComponent,
-        'button-group':    MaterialButtonGroupComponent,
-        'checkbox':        MaterialCheckboxComponent,
-        'checkboxes':      MaterialCheckboxesComponent,
-        'chip-list':       MaterialChipListComponent,
-        'date':            MaterialDatepickerComponent,
-        'file':            MaterialFileComponent,
-        'number':          MaterialNumberComponent,
-        'one-of':          MaterialOneOfComponent,
-        'radios':          MaterialRadiosComponent,
-        'select':          MaterialSelectComponent,
-        'slider':          MaterialSliderComponent,
-        'stepper':         MaterialStepperComponent,
-        'tabs':            MaterialTabsComponent,
-        'text':            MaterialInputComponent,
-        'textarea':        MaterialTextareaComponent,
-        'alt-date':        'date',
-        'any-of':          'one-of',
-        'card':            'section',
-        'color':           'text',
-        'expansion-panel': 'section',
-        'hidden':          'none',
-        'image':           'none',
-        'integer':         'number',
-        'radiobuttons':    'button-group',
-        'range':           'slider',
-        'submit':          'button',
-        'tagsinput':       'chip-list',
-        'wizard':          'stepper',
-      },
-      stylesheets: [
-        '//fonts.googleapis.com/icon?family=Material+Icons',
-        '//fonts.googleapis.com/css?family=Roboto:300,400,500,700',
-      ],
-    },
-    'bootstrap-3': {
-      framework: Bootstrap3FrameworkComponent,
-      stylesheets: [
-        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
-        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css',
-      ],
-      scripts: [
-        '//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js',
-        '//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js',
-        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js',
-      ],
-    },
-    'bootstrap-4': {
-      framework: Bootstrap4FrameworkComponent,
-      stylesheets: [
-        '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css'
-      ],
-      scripts: [
-        '//code.jquery.com/jquery-3.2.1.slim.min.js',
-        '//cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js',
-        '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js',
-      ],
-    }
-  };
+  frameworkLibrary: Framework[] = [];
 
   constructor(
-    @Inject(WidgetLibraryService) private widgetLibrary: WidgetLibraryService
-  ) { }
+    @Inject(WidgetLibraryService) private widgetLibrary: WidgetLibraryService,
+      @Inject(Framework) _frameworks: any[]
+  ) {
+    for (let framework of _frameworks) {
+       this.frameworkLibrary[framework.name] = framework;
+    }
+  }
 
   public setLoadExternalAssets(loadExternalAssets = true): void {
     this.loadExternalAssets = !!loadExternalAssets;
@@ -155,6 +51,10 @@ export class FrameworkLibraryService {
     } else if (typeof framework === 'object' && hasOwn(framework, 'framework')) {
       this.activeFramework = framework;
       registerNewWidgets = true;
+    }
+    if (!this.activeFramework) {
+      console.error('Framework: ' + framework + ' not found');
+      this.activeFramework = new FrameworkNoFramework();
     }
     return registerNewWidgets ?
       this.registerFrameworkWidgets(this.activeFramework) :

--- a/src/lib/src/framework-library/framework.bootstrap3.ts
+++ b/src/lib/src/framework-library/framework.bootstrap3.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { Framework } from './framework';
+
+import { Bootstrap3FrameworkModule } from './bootstrap-3-framework/bootstrap-3-framework.module';
+
+// Bootstrap 3 Framework
+// https://github.com/valor-software/ng2-bootstrap
+import { Bootstrap3FrameworkComponent } from './bootstrap-3-framework/bootstrap-3-framework.component';
+
+@Injectable()
+export class FrameworkBootstrap3 extends Framework {
+    name= 'bootstrap-3'
+    framework= Bootstrap3FrameworkComponent
+    stylesheets= [
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css',
+    ]
+    scripts= [
+      '//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js',
+      '//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js',
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js',
+    ]
+}
+

--- a/src/lib/src/framework-library/framework.bootstrap4.ts
+++ b/src/lib/src/framework-library/framework.bootstrap4.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@angular/core';
+
+import { Framework } from './framework';
+
+// Bootstrap 4 Framework
+// https://github.com/ng-bootstrap/ng-bootstrap
+import { Bootstrap4FrameworkComponent } from './bootstrap-4-framework/bootstrap-4-framework.component';
+
+
+@Injectable()
+export class FrameworkBootstrap4 extends Framework {
+  name= 'bootstrap-4'
+  framework= Bootstrap4FrameworkComponent
+  stylesheets= [
+    '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css'
+  ]
+  scripts= [
+    '//code.jquery.com/jquery-3.2.1.slim.min.js',
+    '//cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js',
+    '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js',
+  ]
+}

--- a/src/lib/src/framework-library/framework.material-design.ts
+++ b/src/lib/src/framework-library/framework.material-design.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@angular/core';
+
+import { Framework } from './framework';
+
+// Material Design Framework
+// https://github.com/angular/material2
+import { FlexLayoutRootComponent } from './material-design-framework/flex-layout-root.component';
+import { FlexLayoutSectionComponent } from './material-design-framework/flex-layout-section.component';
+import { MaterialAddReferenceComponent } from './material-design-framework/material-add-reference.component';
+import { MaterialOneOfComponent } from './material-design-framework/material-one-of.component';
+import { MaterialButtonComponent } from './material-design-framework/material-button.component';
+import { MaterialButtonGroupComponent } from './material-design-framework/material-button-group.component';
+import { MaterialCheckboxComponent } from './material-design-framework/material-checkbox.component';
+import { MaterialCheckboxesComponent } from './material-design-framework/material-checkboxes.component';
+import { MaterialChipListComponent } from './material-design-framework/material-chip-list.component';
+import { MaterialDatepickerComponent } from './material-design-framework/material-datepicker.component';
+import { MaterialFileComponent } from './material-design-framework/material-file.component';
+import { MaterialInputComponent } from './material-design-framework/material-input.component';
+import { MaterialNumberComponent } from './material-design-framework/material-number.component';
+import { MaterialRadiosComponent } from './material-design-framework/material-radios.component';
+import { MaterialSelectComponent } from './material-design-framework/material-select.component';
+import { MaterialSliderComponent } from './material-design-framework/material-slider.component';
+import { MaterialStepperComponent } from './material-design-framework/material-stepper.component';
+import { MaterialTabsComponent } from './material-design-framework/material-tabs.component';
+import { MaterialTextareaComponent } from './material-design-framework/material-textarea.component';
+import { MaterialDesignFrameworkComponent } from './material-design-framework/material-design-framework.component';
+
+@Injectable()
+export class FrameworkMaterialDesign extends Framework {
+  name = 'material-design'
+  framework = MaterialDesignFrameworkComponent
+  widgets = {
+    'root':            FlexLayoutRootComponent,
+    'section':         FlexLayoutSectionComponent,
+    '$ref':            MaterialAddReferenceComponent,
+    'button':          MaterialButtonComponent,
+    'button-group':    MaterialButtonGroupComponent,
+    'checkbox':        MaterialCheckboxComponent,
+    'checkboxes':      MaterialCheckboxesComponent,
+    'chip-list':       MaterialChipListComponent,
+    'date':            MaterialDatepickerComponent,
+    'file':            MaterialFileComponent,
+    'number':          MaterialNumberComponent,
+    'one-of':          MaterialOneOfComponent,
+    'radios':          MaterialRadiosComponent,
+    'select':          MaterialSelectComponent,
+    'slider':          MaterialSliderComponent,
+    'stepper':         MaterialStepperComponent,
+    'tabs':            MaterialTabsComponent,
+    'text':            MaterialInputComponent,
+    'textarea':        MaterialTextareaComponent,
+    'alt-date':        'date',
+    'any-of':          'one-of',
+    'card':            'section',
+    'color':           'text',
+    'expansion-panel': 'section',
+    'hidden':          'none',
+    'image':           'none',
+    'integer':         'number',
+    'radiobuttons':    'button-group',
+    'range':           'slider',
+    'submit':          'button',
+    'tagsinput':       'chip-list',
+    'wizard':          'stepper',
+  }
+  stylesheets = [
+    '//fonts.googleapis.com/icon?family=Material+Icons',
+    '//fonts.googleapis.com/css?family=Roboto:300,400,500,700',
+  ]
+}

--- a/src/lib/src/framework-library/framework.no-framework.ts
+++ b/src/lib/src/framework-library/framework.no-framework.ts
@@ -1,0 +1,12 @@
+import { Inject, Injectable } from '@angular/core';
+
+import { Framework } from './framework';
+
+// No framework - plain HTML controls (styles from form layout only)
+import { NoFrameworkComponent } from './no-framework.component';
+
+@Injectable()
+export class FrameworkNoFramework extends Framework {
+  name = 'no-framework'
+  framework = NoFrameworkComponent
+}

--- a/src/lib/src/framework-library/framework.ts
+++ b/src/lib/src/framework-library/framework.ts
@@ -1,0 +1,11 @@
+import {Injectable} from '@angular/core';
+import {Subject} from 'rxjs/Subject';
+
+@Injectable()
+export class Framework {
+    name: string
+    framework: any
+    widgets?: { [key: string]: any }
+    stylesheets?: string[] = []
+    scripts?: string[] = []
+};

--- a/src/lib/src/i18n/json-schema-form-intl-fr.ts
+++ b/src/lib/src/i18n/json-schema-form-intl-fr.ts
@@ -1,0 +1,82 @@
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from '@angular/core';
+import {Subject} from 'rxjs/Subject';
+
+
+/** Datepicker data that requires internationalization. */
+@Injectable()
+export class JsonSchemaFormIntlFr {
+  /**
+   * Stream that emits whenever the labels here are changed. Use this to notify
+   * components if the labels have changed after initialization.
+   */
+  changes: Subject<void> = new Subject<void>();
+
+  /** A label for the calendar popup (used by screen readers). */
+  validationMessages: any = { // Default error messages
+    required: 'Est obligatoire.',
+    minLength: 'Doit avoir minimum {{minimumLength}} caractères (actuellement: {{currentLength}})',
+    maxLength: 'Doit avoir maximum {{maximumLength}} caractères (actuellement: {{currentLength}})',
+    pattern: 'Doit respecter: {{requiredPattern}}',
+    format: function (error) {
+      switch (error.requiredFormat) {
+        case 'date':
+          return 'Doit être une date, tel que "2000-12-31"';
+        case 'time':
+          return 'Doit être une heure, tel que "16:20" ou "03:14:15.9265"';
+        case 'date-time':
+          return 'Doit être une date et une heure, tel que "2000-03-14T01:59" ou "2000-03-14T01:59:26.535Z"';
+        case 'email':
+          return 'Doit être une adresse e-mail, tel que "name@example.com"';
+        case 'hostname':
+          return 'Doit être un nom de domaine, tel que "example.com"';
+        case 'ipv4':
+          return 'Doit être une adresse IPv4, tel que "127.0.0.1"';
+        case 'ipv6':
+          return 'Doit être une adresse IPv6, tel que "1234:5678:9ABC:DEF0:1234:5678:9ABC:DEF0"';
+        // TODO: add examples for 'uri', 'uri-reference', and 'uri-template'
+        // case 'uri': case 'uri-reference': case 'uri-template':
+        case 'url':
+          return 'Doit être une URL, tel que "http://www.example.com/page.html"';
+        case 'uuid':
+          return 'Doit être un UUID, tel que "12345678-9ABC-DEF0-1234-56789ABCDEF0"';
+        case 'color':
+          return 'Doit être une couleur, tel que "#FFFFFF" or "rgb(255, 255, 255)"';
+        case 'json-pointer':
+          return 'Doit être un JSON Pointer, tel que "/pointer/to/something"';
+        case 'relative-json-pointer':
+          return 'Doit être un relative JSON Pointer, tel que "2/pointer/to/something"';
+        case 'regex':
+          return 'Doit être une expression régulière, tel que "(1-)?\\d{3}-\\d{3}-\\d{4}"';
+        default:
+          return 'Doit être avoir le format correct: ' + error.requiredFormat;
+      }
+    },
+    minimum: 'Doit être supérieur à {{minimumValue}}',
+    exclusiveMinimum: 'Doit avoir minimum {{exclusiveMinimumValue}} charactères',
+    maximum: 'Doit être inférieur à {{maximumValue}}',
+    exclusiveMaximum: 'Doit avoir maximum {{exclusiveMaximumValue}} charactères',
+    multipleOf: function (error) {
+      if ((1 / error.multipleOfValue) % 10 === 0) {
+        const decimals = Math.log10(1 / error.multipleOfValue);
+        return `Doit comporter ${decimals} ou moins de decimales.`;
+      } else {
+        return `Doit être un multiple de ${error.multipleOfValue}.`;
+      }
+    },
+    minProperties: 'Doit comporter au minimum {{minimumProperties}} éléments',
+    maxProperties: 'Doit comporter au maximum {{maximumProperties}} éléments',
+    minItems: 'Doit comporter au minimum {{minimumItems}} éléments',
+    maxItems: 'Doit comporter au maximum {{minimumItems}} éléments',
+    uniqueItems: 'Tous les éléments doivent être uniques',
+    // Note: No default error messages for 'type', 'const', 'enum', or 'dependencies'
+  };
+}

--- a/src/lib/src/i18n/json-schema-form-intl-fr.ts
+++ b/src/lib/src/i18n/json-schema-form-intl-fr.ts
@@ -1,24 +1,10 @@
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
 import {Injectable} from '@angular/core';
-import {Subject} from 'rxjs/Subject';
 
+import {JsonSchemaFormIntl} from '../json-schema-form-intl';
 
 /** Datepicker data that requires internationalization. */
 @Injectable()
-export class JsonSchemaFormIntlFr {
-  /**
-   * Stream that emits whenever the labels here are changed. Use this to notify
-   * components if the labels have changed after initialization.
-   */
-  changes: Subject<void> = new Subject<void>();
+export class JsonSchemaFormIntlFr  extends JsonSchemaFormIntl {
 
   /** A label for the calendar popup (used by screen readers). */
   validationMessages: any = { // Default error messages

--- a/src/lib/src/json-schema-form-intl.ts
+++ b/src/lib/src/json-schema-form-intl.ts
@@ -1,16 +1,7 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
 import {Injectable} from '@angular/core';
 import {Subject} from 'rxjs/Subject';
 
-
-/** Datepicker data that requires internationalization. */
+/** JsonSchemaForm data that requires internationalization. */
 @Injectable()
 export class JsonSchemaFormIntl {
   /**

--- a/src/lib/src/json-schema-form-intl.ts
+++ b/src/lib/src/json-schema-form-intl.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from '@angular/core';
+import {Subject} from 'rxjs/Subject';
+
+
+/** Datepicker data that requires internationalization. */
+@Injectable()
+export class JsonSchemaFormIntl {
+  /**
+   * Stream that emits whenever the labels here are changed. Use this to notify
+   * components if the labels have changed after initialization.
+   */
+  changes: Subject<void> = new Subject<void>();
+
+  /** A label for the calendar popup (used by screen readers). */
+  validationMessages: any = { // Default error messages
+    required: 'This field is required.',
+    minLength: 'Must be {{minimumLength}} characters or longer (current length: {{currentLength}})',
+    maxLength: 'Must be {{maximumLength}} characters or shorter (current length: {{currentLength}})',
+    pattern: 'Must match pattern: {{requiredPattern}}',
+    format: function (error) {
+      switch (error.requiredFormat) {
+        case 'date':
+          return 'Must be a date, like "2000-12-31"';
+        case 'time':
+          return 'Must be a time, like "16:20" or "03:14:15.9265"';
+        case 'date-time':
+          return 'Must be a date-time, like "2000-03-14T01:59" or "2000-03-14T01:59:26.535Z"';
+        case 'email':
+          return 'Must be an email address, like "name@example.com"';
+        case 'hostname':
+          return 'Must be a hostname, like "example.com"';
+        case 'ipv4':
+          return 'Must be an IPv4 address, like "127.0.0.1"';
+        case 'ipv6':
+          return 'Must be an IPv6 address, like "1234:5678:9ABC:DEF0:1234:5678:9ABC:DEF0"';
+        // TODO: add examples for 'uri', 'uri-reference', and 'uri-template'
+        // case 'uri': case 'uri-reference': case 'uri-template':
+        case 'url':
+          return 'Must be a url, like "http://www.example.com/page.html"';
+        case 'uuid':
+          return 'Must be a uuid, like "12345678-9ABC-DEF0-1234-56789ABCDEF0"';
+        case 'color':
+          return 'Must be a color, like "#FFFFFF" or "rgb(255, 255, 255)"';
+        case 'json-pointer':
+          return 'Must be a JSON Pointer, like "/pointer/to/something"';
+        case 'relative-json-pointer':
+          return 'Must be a relative JSON Pointer, like "2/pointer/to/something"';
+        case 'regex':
+          return 'Must be a regular expression, like "(1-)?\\d{3}-\\d{3}-\\d{4}"';
+        default:
+          return 'Must be a correctly formatted ' + error.requiredFormat;
+      }
+    },
+    minimum: 'Must be {{minimumValue}} or more',
+    exclusiveMinimum: 'Must be more than {{exclusiveMinimumValue}}',
+    maximum: 'Must be {{maximumValue}} or less',
+    exclusiveMaximum: 'Must be less than {{exclusiveMaximumValue}}',
+    multipleOf: function (error) {
+      if ((1 / error.multipleOfValue) % 10 === 0) {
+        const decimals = Math.log10(1 / error.multipleOfValue);
+        return `Must have ${decimals} or fewer decimal places.`;
+      } else {
+        return `Must be a multiple of ${error.multipleOfValue}.`;
+      }
+    },
+    minProperties: 'Must have {{minimumProperties}} or more items (current items: {{currentProperties}})',
+    maxProperties: 'Must have {{maximumProperties}} or fewer items (current items: {{currentProperties}})',
+    minItems: 'Must have {{minimumItems}} or more items (current items: {{currentItems}})',
+    maxItems: 'Must have {{maximumItems}} or fewer items (current items: {{currentItems}})',
+    uniqueItems: 'All items must be unique',
+    // Note: No default error messages for 'type', 'const', 'enum', or 'dependencies'
+  };
+}

--- a/src/lib/src/json-schema-form.component.ts
+++ b/src/lib/src/json-schema-form.component.ts
@@ -570,8 +570,7 @@ export class JsonSchemaFormComponent implements ControlValueAccessor, OnChanges,
     } else if (this.form && isArray(this.form.layout)) {
       this.jsf.layout = _.cloneDeep(this.form.layout);
     } else {
-      this.jsf.layout = this.jsf.formOptions.addSubmit === false ?
-        [ '*' ] : [ '*', { type: 'submit', title: 'Submit' } ];
+      this.jsf.layout = ['*'];
     }
 
     // Check for alternate layout inputs

--- a/src/lib/src/json-schema-form.module.ts
+++ b/src/lib/src/json-schema-form.module.ts
@@ -9,7 +9,6 @@ import { JsonSchemaFormComponent } from './json-schema-form.component';
 
 import { JsonSchemaFormService } from './json-schema-form.service';
 import { FrameworkLibraryService } from './framework-library/framework-library.service';
-import { WidgetLibraryService } from './widget-library/widget-library.service';
 
 @NgModule({
   imports: [
@@ -21,7 +20,7 @@ import { WidgetLibraryService } from './widget-library/widget-library.service';
     JsonSchemaFormComponent, FrameworkLibraryModule, WidgetLibraryModule
   ],
   providers: [
-    JsonSchemaFormService, FrameworkLibraryService, WidgetLibraryService
+    JsonSchemaFormService, FrameworkLibraryService
   ]
 })
 export class JsonSchemaFormModule { }

--- a/src/lib/src/json-schema-form.service.ts
+++ b/src/lib/src/json-schema-form.service.ts
@@ -21,6 +21,7 @@ import {
   buildFormGroup, buildFormGroupTemplate, formatFormData, getControl
 } from './shared/form-group.functions';
 import { buildLayout, getLayoutNode } from './shared/layout.functions';
+import { JsonSchemaFormIntl } from './json-schema-form-intl';
 
 export interface TitleMapItem {
   name?: string, value?: any, checked?: boolean, group?: string, items?: TitleMapItem[]
@@ -28,6 +29,7 @@ export interface TitleMapItem {
 export interface ErrorMessages {
   [control_name: string]: { message: string|Function|Object, code: string }[]
 };
+
 
 @Injectable()
 export class JsonSchemaFormService {
@@ -110,67 +112,14 @@ export class JsonSchemaFormService {
       disabled: false, // Set control as disabled? (not editable, and excluded from output)
       readonly: false, // Set control as read only? (not editable, but included in output)
       returnEmptyFields: true, // return values for fields that contain no data?
-      validationMessages: { // Default error messages
-        required: 'This field is required.',
-        minLength: 'Must be {{minimumLength}} characters or longer (current length: {{currentLength}})',
-        maxLength: 'Must be {{maximumLength}} characters or shorter (current length: {{currentLength}})',
-        pattern: 'Must match pattern: {{requiredPattern}}',
-        format: function (error) {
-          switch (error.requiredFormat) {
-            case 'date':
-              return 'Must be a date, like "2000-12-31"';
-            case 'time':
-              return 'Must be a time, like "16:20" or "03:14:15.9265"';
-            case 'date-time':
-              return 'Must be a date-time, like "2000-03-14T01:59" or "2000-03-14T01:59:26.535Z"';
-            case 'email':
-              return 'Must be an email address, like "name@example.com"';
-            case 'hostname':
-              return 'Must be a hostname, like "example.com"';
-            case 'ipv4':
-              return 'Must be an IPv4 address, like "127.0.0.1"';
-            case 'ipv6':
-              return 'Must be an IPv6 address, like "1234:5678:9ABC:DEF0:1234:5678:9ABC:DEF0"';
-            // TODO: add examples for 'uri', 'uri-reference', and 'uri-template'
-            // case 'uri': case 'uri-reference': case 'uri-template':
-            case 'url':
-              return 'Must be a url, like "http://www.example.com/page.html"';
-            case 'uuid':
-              return 'Must be a uuid, like "12345678-9ABC-DEF0-1234-56789ABCDEF0"';
-            case 'color':
-              return 'Must be a color, like "#FFFFFF" or "rgb(255, 255, 255)"';
-            case 'json-pointer':
-              return 'Must be a JSON Pointer, like "/pointer/to/something"';
-            case 'relative-json-pointer':
-              return 'Must be a relative JSON Pointer, like "2/pointer/to/something"';
-            case 'regex':
-              return 'Must be a regular expression, like "(1-)?\\d{3}-\\d{3}-\\d{4}"';
-            default:
-              return 'Must be a correctly formatted ' + error.requiredFormat;
-          }
-        },
-        minimum: 'Must be {{minimumValue}} or more',
-        exclusiveMinimum: 'Must be more than {{exclusiveMinimumValue}}',
-        maximum: 'Must be {{maximumValue}} or less',
-        exclusiveMaximum: 'Must be less than {{exclusiveMaximumValue}}',
-        multipleOf: function (error) {
-          if ((1 / error.multipleOfValue) % 10 === 0) {
-            const decimals = Math.log10(1 / error.multipleOfValue);
-            return `Must have ${decimals} or fewer decimal places.`;
-          } else {
-            return `Must be a multiple of ${error.multipleOfValue}.`;
-          }
-        },
-        minProperties: 'Must have {{minimumProperties}} or more items (current items: {{currentProperties}})',
-        maxProperties: 'Must have {{maximumProperties}} or fewer items (current items: {{currentProperties}})',
-        minItems: 'Must have {{minimumItems}} or more items (current items: {{currentItems}})',
-        maxItems: 'Must have {{maximumItems}} or fewer items (current items: {{currentItems}})',
-        uniqueItems: 'All items must be unique',
-        // Note: No default error messages for 'type', 'const', 'enum', or 'dependencies'
-      },
+      validationMessages: {} // injected
     },
   };
 
+  constructor(public _intl: JsonSchemaFormIntl) {
+    // inject translation
+    this.defaultFormOptions.defautWidgetOptions.validationMessages = _.cloneDeep(_intl.validationMessages);
+  }
   getData() { return this.data; }
 
   getSchema() { return this.schema; }

--- a/src/lib/src/shared/json-schema.functions.ts
+++ b/src/lib/src/shared/json-schema.functions.ts
@@ -438,7 +438,7 @@ export function updateInputOptions(layoutNode, schema, jsf) {
       } else if (JsonPointer.has(schema, '/items/enum')) {
         newOptions.enum = schema.items.enum;
         if (!hasOwn(newOptions, 'enumNames') && JsonPointer.has(schema, '/items/enumNames')) {
-          newOptions.enum = schema.items.enumNames;
+          newOptions.enumNames = schema.items.enumNames;
         }
       } else if (JsonPointer.has(schema, '/items/oneOf')) {
         newTitleMap = getTitleMapFromOneOf(schema.items, newOptions.flatList);

--- a/src/lib/src/shared/layout.functions.ts
+++ b/src/lib/src/shared/layout.functions.ts
@@ -62,8 +62,6 @@ export function buildLayout(jsf, widgetLibrary) {
         if (hasOwn(newNode.options, 'legend')) {
           newNode.options.title = newNode.options.legend;
           delete newNode.options.legend;
-        } else if (hasOwn(newNode, 'name') && !/^\d+$/.test(newNode.name)) {
-          newNode.options.title = fixTitle(newNode.name);
         }
       }
       if (!hasOwn(newNode.options, 'validationMessages')) {
@@ -167,9 +165,6 @@ export function buildLayout(jsf, widgetLibrary) {
       const LastKey = JsonPointer.toKey(newNode.dataPointer);
       if (!newNode.name && isString(LastKey) && LastKey !== '-') {
         newNode.name = LastKey;
-        if (!newNode.options.title && !/^\d+$/.test(newNode.name)) {
-          newNode.options.title = fixTitle(newNode.name);
-        }
       }
       const shortDataPointer = removeRecursiveReferences(
         newNode.dataPointer, jsf.dataRecursiveRefMap, jsf.arrayMap
@@ -253,6 +248,10 @@ export function buildLayout(jsf, widgetLibrary) {
       } else {
         // TODO: create item in FormGroup model from layout key (?)
         updateInputOptions(newNode, {}, jsf);
+      }
+
+      if (!newNode.options.hasOwnProperty('title') && !/^\d+$/.test(newNode.name)) {
+        newNode.options.title = fixTitle(newNode.name);
       }
 
       if (hasOwn(newNode.options, 'copyValueTo')) {

--- a/src/lib/src/widget-library/section.component.ts
+++ b/src/lib/src/widget-library/section.component.ts
@@ -40,6 +40,12 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [class]="options?.labelHtmlClass || ''"
         [innerHTML]="sectionTitle"
         (click)="toggleExpanded()"></legend>
+      <div *ngIf="options?.messageLocation !== 'bottom'">
+        <p *ngIf="options?.description"
+        class="help-block"
+        [class]="options?.labelHelpBlockClass || ''"
+        [innerHTML]="options?.description"></p>
+      </div>
       <root-widget *ngIf="expanded"
         [dataIndex]="dataIndex"
         [layout]="layoutNode.items"
@@ -54,6 +60,12 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [style.flex-direction]="getFlexAttribute('flex-direction')"
         [style.flex-wrap]="getFlexAttribute('flex-wrap')"
         [style.justify-content]="getFlexAttribute('justify-content')"></root-widget>
+      <div *ngIf="options?.messageLocation === 'bottom'">
+        <p *ngIf="options?.description"
+        class="help-block"
+        [class]="options?.labelHelpBlockClass || ''"
+        [innerHTML]="options?.description"></p>
+      </div>
     </fieldset>`,
   styles: [`
     .legend { font-weight: bold; }


### PR DESCRIPTION
## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

1. Use the title specified in the schema instead of the key name 
before : ![1_before](https://user-images.githubusercontent.com/33874838/33666592-c21844aa-da9a-11e7-9de3-bd747eae71e4.png)
after : ![1_after](https://user-images.githubusercontent.com/33874838/33666591-c1fe5df6-da9a-11e7-9562-55d6aebcba4b.png)

2. Avoid double margin after a flex section
before : ![2_before](https://user-images.githubusercontent.com/33874838/33666594-c25f93a0-da9a-11e7-96d1-967d02797d0d.png)
after : ![2_after](https://user-images.githubusercontent.com/33874838/33666593-c232d7c0-da9a-11e7-9332-332ff5587a88.png)

3. bootstrap: Use <legend> for the title of "fieldset" section
before: ![3and5_before](https://user-images.githubusercontent.com/33874838/33666596-c2a43d7a-da9a-11e7-8e66-933ce404cee4.png)
after: ![3and5_after](https://user-images.githubusercontent.com/33874838/33666595-c27a578a-da9a-11e7-8c43-aa471e4918cd.png)

4.  Not needed: submit button is added layout.function.ts 

5.  bootstrap: Allow description for fieldset section
see 3

## New behavior
6. Translation of error messages
before: ![6_before](https://user-images.githubusercontent.com/33874838/33666599-c2dcf368-da9a-11e7-91c9-01708622d614.png)
after: ![6_after](https://user-images.githubusercontent.com/33874838/33666597-c2c15eaa-da9a-11e7-89d7-1fe6239fce78.png)


## Does this PR introduce a breaking change?
[ ] Yes
[x] No

## Any other relevant information
