### PR TITLE
Fixed lazy loaded modules issue

### DIFF
--- a/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.module.ts
+++ b/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.module.ts
@@ -1,12 +1,14 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
+
 import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { Bootstrap3FrameworkComponent } from './bootstrap-3-framework.component';
 
 @NgModule({
-  imports:         [ CommonModule ],
+  imports:         [ CommonModule, WidgetLibraryModule ],
   declarations:    [ Bootstrap3FrameworkComponent ],
   exports:         [ Bootstrap3FrameworkComponent ],
   entryComponents: [ Bootstrap3FrameworkComponent ]

--- a/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.module.ts
+++ b/src/lib/src/framework-library/bootstrap-3-framework/bootstrap-3-framework.module.ts
@@ -1,18 +1,21 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
-
-import { WidgetLibraryService } from '../../widget-library/widget-library.service';
-import { FrameworkLibraryService } from '../framework-library.service';
+import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { Bootstrap3FrameworkComponent } from './bootstrap-3-framework.component';
 
 @NgModule({
-  imports:         [ CommonModule, WidgetLibraryModule ],
+  imports:         [ CommonModule ],
   declarations:    [ Bootstrap3FrameworkComponent ],
   exports:         [ Bootstrap3FrameworkComponent ],
-  entryComponents: [ Bootstrap3FrameworkComponent ],
-  providers:       [ WidgetLibraryService, FrameworkLibraryService ]
+  entryComponents: [ Bootstrap3FrameworkComponent ]
 })
-export class Bootstrap3FrameworkModule { }
+export class Bootstrap3FrameworkModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: Bootstrap3FrameworkModule,
+      providers: [ JsonSchemaFormService ]
+    }
+  }
+}

--- a/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.module.ts
+++ b/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.module.ts
@@ -1,12 +1,14 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
+
 import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { Bootstrap4FrameworkComponent } from './bootstrap-4-framework.component';
 
 @NgModule({
-  imports:         [ CommonModule ],
+  imports:         [ CommonModule, WidgetLibraryModule ],
   declarations:    [ Bootstrap4FrameworkComponent ],
   exports:         [ Bootstrap4FrameworkComponent ],
   entryComponents: [ Bootstrap4FrameworkComponent ]

--- a/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.module.ts
+++ b/src/lib/src/framework-library/bootstrap-4-framework/bootstrap-4-framework.module.ts
@@ -1,18 +1,21 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
-
-import { WidgetLibraryService } from '../../widget-library/widget-library.service';
-import { FrameworkLibraryService } from '../framework-library.service';
+import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { Bootstrap4FrameworkComponent } from './bootstrap-4-framework.component';
 
 @NgModule({
-  imports:         [ CommonModule, WidgetLibraryModule ],
+  imports:         [ CommonModule ],
   declarations:    [ Bootstrap4FrameworkComponent ],
   exports:         [ Bootstrap4FrameworkComponent ],
-  entryComponents: [ Bootstrap4FrameworkComponent ],
-  providers:       [ WidgetLibraryService, FrameworkLibraryService ]
+  entryComponents: [ Bootstrap4FrameworkComponent ]
 })
-export class Bootstrap4FrameworkModule { }
+export class Bootstrap4FrameworkModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: Bootstrap4FrameworkModule,
+      providers: [ JsonSchemaFormService ]
+    }
+  }
+}

--- a/src/lib/src/framework-library/framework-library.module.ts
+++ b/src/lib/src/framework-library/framework-library.module.ts
@@ -1,9 +1,7 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { WidgetLibraryModule } from '../widget-library/widget-library.module';
 import { WidgetLibraryService } from '../widget-library/widget-library.service';
-
 import { FrameworkLibraryService } from './framework-library.service';
 
 import { Bootstrap3FrameworkModule } from './bootstrap-3-framework/bootstrap-3-framework.module';
@@ -14,7 +12,7 @@ import { Bootstrap4FrameworkModule } from './bootstrap-4-framework/bootstrap-4-f
 
 @NgModule({
   imports:         [
-    CommonModule, WidgetLibraryModule,
+    CommonModule,
     Bootstrap3FrameworkModule, MaterialDesignFrameworkModule, Bootstrap4FrameworkModule
   ],
   declarations:    [ NoFrameworkComponent ],
@@ -22,7 +20,13 @@ import { Bootstrap4FrameworkModule } from './bootstrap-4-framework/bootstrap-4-f
     NoFrameworkComponent,
     Bootstrap3FrameworkModule, MaterialDesignFrameworkModule, Bootstrap4FrameworkModule
   ],
-  entryComponents: [ NoFrameworkComponent ],
-  providers:       [ WidgetLibraryService, FrameworkLibraryService ]
+  entryComponents: [ NoFrameworkComponent ]
 })
-export class FrameworkLibraryModule { }
+export class FrameworkLibraryModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MaterialDesignFrameworkModule,
+      providers: [ WidgetLibraryService, FrameworkLibraryService ]
+    }
+  }
+}

--- a/src/lib/src/framework-library/framework-library.module.ts
+++ b/src/lib/src/framework-library/framework-library.module.ts
@@ -2,6 +2,8 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { WidgetLibraryService } from '../widget-library/widget-library.service';
+import { WidgetLibraryModule } from '../widget-library/widget-library.module';
+
 import { FrameworkLibraryService } from './framework-library.service';
 
 import { Bootstrap3FrameworkModule } from './bootstrap-3-framework/bootstrap-3-framework.module';
@@ -12,7 +14,7 @@ import { Bootstrap4FrameworkModule } from './bootstrap-4-framework/bootstrap-4-f
 
 @NgModule({
   imports:         [
-    CommonModule,
+    CommonModule, WidgetLibraryModule,
     Bootstrap3FrameworkModule, MaterialDesignFrameworkModule, Bootstrap4FrameworkModule
   ],
   declarations:    [ NoFrameworkComponent ],
@@ -25,7 +27,7 @@ import { Bootstrap4FrameworkModule } from './bootstrap-4-framework/bootstrap-4-f
 export class FrameworkLibraryModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: MaterialDesignFrameworkModule,
+      ngModule: FrameworkLibraryModule,
       providers: [ WidgetLibraryService, FrameworkLibraryService ]
     }
   }

--- a/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
@@ -24,6 +24,7 @@ export const ANGULAR_MATERIAL_MODULES = [
  * MatToolbarModule,
  */
 
+import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
 import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { MATERIAL_FRAMEWORK_COMPONENTS } from './index';
@@ -31,7 +32,7 @@ import { MATERIAL_FRAMEWORK_COMPONENTS } from './index';
 @NgModule({
   imports: [
     CommonModule, FormsModule, ReactiveFormsModule, FlexLayoutModule,
-    ...ANGULAR_MATERIAL_MODULES
+    ...ANGULAR_MATERIAL_MODULES, WidgetLibraryModule
   ],
   declarations:    [ ...MATERIAL_FRAMEWORK_COMPONENTS ],
   exports:         [ ...MATERIAL_FRAMEWORK_COMPONENTS ],

--- a/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-design-framework.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -24,7 +24,6 @@ export const ANGULAR_MATERIAL_MODULES = [
  * MatToolbarModule,
  */
 
-import { WidgetLibraryModule } from '../../widget-library/widget-library.module';
 import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 import { MATERIAL_FRAMEWORK_COMPONENTS } from './index';
@@ -32,11 +31,17 @@ import { MATERIAL_FRAMEWORK_COMPONENTS } from './index';
 @NgModule({
   imports: [
     CommonModule, FormsModule, ReactiveFormsModule, FlexLayoutModule,
-    ...ANGULAR_MATERIAL_MODULES, WidgetLibraryModule
+    ...ANGULAR_MATERIAL_MODULES
   ],
   declarations:    [ ...MATERIAL_FRAMEWORK_COMPONENTS ],
   exports:         [ ...MATERIAL_FRAMEWORK_COMPONENTS ],
-  entryComponents: [ ...MATERIAL_FRAMEWORK_COMPONENTS ],
-  providers:       [ JsonSchemaFormService ]
+  entryComponents: [ ...MATERIAL_FRAMEWORK_COMPONENTS ]
 })
-export class MaterialDesignFrameworkModule { }
+export class MaterialDesignFrameworkModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MaterialDesignFrameworkModule,
+      providers: [ JsonSchemaFormService ]
+    }
+  }
+}

--- a/src/lib/src/json-schema-form.module.ts
+++ b/src/lib/src/json-schema-form.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -8,8 +8,6 @@ import { WidgetLibraryModule } from './widget-library/widget-library.module';
 import { JsonSchemaFormComponent } from './json-schema-form.component';
 
 import { JsonSchemaFormService } from './json-schema-form.service';
-import { FrameworkLibraryService } from './framework-library/framework-library.service';
-import { WidgetLibraryService } from './widget-library/widget-library.service';
 
 @NgModule({
   imports: [
@@ -19,9 +17,16 @@ import { WidgetLibraryService } from './widget-library/widget-library.service';
   declarations: [ JsonSchemaFormComponent ],
   exports: [
     JsonSchemaFormComponent, FrameworkLibraryModule, WidgetLibraryModule
-  ],
-  providers: [
-    JsonSchemaFormService, FrameworkLibraryService, WidgetLibraryService
   ]
 })
-export class JsonSchemaFormModule { }
+export class JsonSchemaFormModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: JsonSchemaFormModule,
+      providers: [ ]
+        .concat([JsonSchemaFormService])
+        .concat(FrameworkLibraryModule.forRoot().providers)
+        .concat(WidgetLibraryModule.forRoot().providers)
+    }
+  }
+}

--- a/src/lib/src/widget-library/widget-library.module.ts
+++ b/src/lib/src/widget-library/widget-library.module.ts
@@ -1,10 +1,9 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { OrderableDirective } from '../shared/orderable.directive';
 
-import { WidgetLibraryService } from './widget-library.service';
 import { JsonSchemaFormService } from '../json-schema-form.service';
 
 import { BASIC_WIDGETS } from './index';
@@ -14,6 +13,13 @@ import { BASIC_WIDGETS } from './index';
   declarations:    [ ...BASIC_WIDGETS, OrderableDirective ],
   exports:         [ ...BASIC_WIDGETS, OrderableDirective ],
   entryComponents: [ ...BASIC_WIDGETS ],
-  providers:       [ JsonSchemaFormService, WidgetLibraryService ]
+  providers:       [ JsonSchemaFormService ]
 })
-export class WidgetLibraryModule { }
+export class WidgetLibraryModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: WidgetLibraryModule,
+      providers: [ JsonSchemaFormService ]
+    }
+  }
+}


### PR DESCRIPTION
Declared providers using forRoot
so that Lazy loaded modules
do not redeclare the providers

## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->


## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->


## Does this PR introduce a breaking change?
[x] Yes
[ ] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->
Existing applications will need to use the static forRoot method when importing modules


## Any other relevant information
