### PR TITLE
Fixes #168

### DIFF
--- a/src/lib/src/shared/layout.functions.ts
+++ b/src/lib/src/shared/layout.functions.ts
@@ -167,9 +167,6 @@ export function buildLayout(jsf, widgetLibrary) {
       const LastKey = JsonPointer.toKey(newNode.dataPointer);
       if (!newNode.name && isString(LastKey) && LastKey !== '-') {
         newNode.name = LastKey;
-        if (!newNode.options.title && !/^\d+$/.test(newNode.name)) {
-          newNode.options.title = fixTitle(newNode.name);
-        }
       }
       const shortDataPointer = removeRecursiveReferences(
         newNode.dataPointer, jsf.dataRecursiveRefMap, jsf.arrayMap
@@ -253,6 +250,10 @@ export function buildLayout(jsf, widgetLibrary) {
       } else {
         // TODO: create item in FormGroup model from layout key (?)
         updateInputOptions(newNode, {}, jsf);
+      }
+
+      if (!newNode.options.title && !/^\d+$/.test(newNode.name)) {
+        newNode.options.title = fixTitle(newNode.name);
       }
 
       if (hasOwn(newNode.options, 'copyValueTo')) {


### PR DESCRIPTION
The derived Title was being set too early
which caused it to overwrite the one defined
in the schema when updateInputOptions ran.
Moved the setting the of title later in the stack
so that updateInputOptions runs first

## PR Type
What changes does this PR include (check all that apply)?
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->


## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->


## Does this PR introduce a breaking change?
[ ] Yes
[ ] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->


## Any other relevant information
