### PR TITLE
Fixes #179

### DIFF
--- a/src/lib/src/shared/jsonpointer.functions.ts
+++ b/src/lib/src/shared/jsonpointer.functions.ts
@@ -185,7 +185,7 @@ export class JsonPointer {
    */
   static set(object, pointer, value, insert = false) {
     const keyArray = this.parse(pointer);
-    if (keyArray !== null) {
+    if (keyArray !== null && keyArray.length) {
       let subObject = object;
       for (let i = 0; i < keyArray.length - 1; ++i) {
         let key = keyArray[i];


### PR DESCRIPTION
When the keyArray is empty the code tried to access keyArray.length-1 which resulted in a redundant "undefined"
entry being added to the data top level when "return empty fields" is set.

## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix

## Related issue / current behavior
[#179](https://github.com/dschnelldavis/angular2-json-schema-form/issues/179)

## New behavior
Fixed

## Does this PR introduce a breaking change?
[ ] Yes
[x] No