### PR TITLE
 Fixes issue with readOnly property

### DIFF
--- a/src/lib/src/shared/json-schema.functions.ts
+++ b/src/lib/src/shared/json-schema.functions.ts
@@ -447,6 +447,12 @@ export function updateInputOptions(layoutNode, schema, jsf) {
     }
   }
 
+  // Map the readOnly property from JsonSchema's camelcased to non-camelcased
+  if (hasOwn(newOptions, 'readOnly')) {
+    newOptions.readonly = newOptions.readOnly;
+    delete newOptions.readOnly;
+  }
+
   // If schema type is integer, enforce by setting multipleOf = 1
   if (schema.type === 'integer' && !hasValue(newOptions.multipleOf)) {
     newOptions.multipleOf = 1;


### PR DESCRIPTION
JsonSchema specifies that the readOnly
property be camel-case, so we need to
map that over to the lower case javascript
property that is used internally.

## PR Type
What changes does this PR include (check all that apply)?
[x ] Bugfix

## Related issue / current behavior
When setting the readOnly property in JsonSchema, the value is ignored unless you specify it in lowercase.  The spec defines the attribute to be lower camel-cased.


## New behavior
readOnly properties are now properly mapped over to the internal lowercased name.


## Does this PR introduce a breaking change?
[ ] Yes
[x ] No
