### PR TITLE
fix #274 Button close does not exist in the NoFramework Component.  fix for set error: Invalid JSON on returnEmptyFields: true #282

### DIFF
--- a/src/lib/src/framework-library/no-framework/no-framework.component.ts
+++ b/src/lib/src/framework-library/no-framework/no-framework.component.ts
@@ -1,15 +1,62 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import * as _ from 'lodash';
+import { JsonSchemaFormService } from '../../json-schema-form.service';
 
 @Component({
   selector: 'no-framework',
   template: `
+  <button style='float:right;clear: right;' *ngIf="showRemoveButton"
+  type="button"
+  (click)="removeItem()">
+  <span aria-hidden="true">&times;</span>
+</button>
     <select-widget-widget
       [dataIndex]="dataIndex"
       [layoutIndex]="layoutIndex"
-      [layoutNode]="layoutNode"></select-widget-widget>`,
+      [layoutNode]="layoutNode"></select-widget-widget>
+      `,
 })
-export class NoFrameworkComponent {
+export class NoFrameworkComponent implements OnInit {
+
+  options: any; // Options used in this framework
+  parentArray: any = null;
+  isOrderable = false;
+
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
   @Input() dataIndex: number[];
+
+  constructor(
+    public jsf: JsonSchemaFormService
+  ) { }
+
+  ngOnInit() {
+    this.options = _.cloneDeep(this.layoutNode.options);
+    if (this.layoutNode.arrayItem && this.layoutNode.type !== '$ref') {
+      this.parentArray = this.jsf.getParentNode(this);
+      if (this.parentArray) {
+        this.isOrderable = this.layoutNode.arrayItemType === 'list' &&
+          !this.options.readonly && this.parentArray.options.orderable;
+      }
+    }
+  }
+
+
+  get showRemoveButton(): boolean {
+    if (!this.options.removable || this.options.readonly ||
+      this.layoutNode.type === '$ref'
+    ) { return false; }
+    if (this.layoutNode.recursiveReference) { return true; }
+    if (!this.layoutNode.arrayItem || !this.parentArray) { return false; }
+    // If array length <= minItems, don't allow removing any items
+    return this.parentArray.items.length - 1 <= this.parentArray.options.minItems ? false :
+      // For removable list items, allow removing any item
+      this.layoutNode.arrayItemType === 'list' ? true :
+        // For removable tuple items, only allow removing last item in list
+        this.layoutIndex[this.layoutIndex.length - 1] === this.parentArray.items.length - 2;
+  }
+
+  removeItem() {
+    this.jsf.removeItem(this);
+  }
 }

--- a/src/lib/src/shared/jsonpointer.functions.ts
+++ b/src/lib/src/shared/jsonpointer.functions.ts
@@ -392,7 +392,10 @@ export class JsonPointer {
       console.error(`forEachDeep error: Iterator is not a function:`, fn);
       return;
     }
+    const firstPointerPart = pointer.split('/')[1];
+    if (firstPointerPart && rootObject.hasOwnProperty(firstPointerPart)) {
     if (!bottomUp) { fn(object, pointer, rootObject); }
+    }
     if (isObject(object) || isArray(object)) {
       for (let key of Object.keys(object)) {
         const newPointer = pointer + '/' + this.escape(key);


### PR DESCRIPTION
This is bug fixing commit.

## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->
Related issues : 
-Button close does not exist in the NoFramework Component #274 / 
-set error: Invalid JSON on returnEmptyFields: true #282
current behaviour : 
- #274 Whenever choosing the NoFramework , displayed items of array layout can not be closed . Button close does not exist in a NoFramework Component, so you can add items but you can not delete.
- #282 whenever choosing the option < returnEmptyFields = true > an error: Invalid JSON occures. 

## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->
-Button close apears now , and you can delete any item from array .
-No error: Invalid JSON logged in the console any more.

## Does this PR introduce a breaking change?
[ ] Yes
[x] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->


## Any other relevant information
