### PR TITLE
fix Bug with updateForm method when updating input data only

### DIFF
--- a/src/lib/src/json-schema-form.component.ts
+++ b/src/lib/src/json-schema-form.component.ts
@@ -223,16 +223,8 @@ export class JsonSchemaFormComponent implements ControlValueAccessor, OnChanges,
       }
 
       // If only input values have changed, update the form values
-      if (changedInput.length === 1 && changedInput[0] === this.formValuesInput) {
-        if (this.formValuesInput.indexOf('.') === -1) {
-          this.setFormValues(this[this.formValuesInput], resetFirst);
-        } else {
-          const [input, key] = this.formValuesInput.split('.');
-          this.setFormValues(this[input][key], resetFirst);
-        }
-
       // If anything else has changed, re-render the entire form
-      } else if (changedInput.length) {
+      if (changedInput.length) {
         this.initializeForm();
         if (this.onChange) { this.onChange(this.jsf.formValues); }
         if (this.onTouched) { this.onTouched(this.jsf.formValues); }


### PR DESCRIPTION
arrays in data that changed in size needs to increase or decrease formGroup

## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->
if we updateForm with changes in input only the initializeForm is not triggered.

possible fixes this:
https://github.com/dschnelldavis/angular2-json-schema-form/issues/256
maybe this:
https://github.com/dschnelldavis/angular2-json-schema-form/issues/195


## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->
keep it stupid simple it always rerender Form even if the change is only in data


## Does this PR introduce a breaking change?
[ ] Yes
[x] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->


## Any other relevant information
The Change will possibly slow down as each data change will now trigger a Form rerender but its clean simple stupid and not performance optimized as i currently do not see any problems.
CleanCode:
http://clean-code-developer.com/grades/grade-1-red/#Keep_it_simple_stupid_KISS 
http://clean-code-developer.com/grades/grade-1-red/#Beware_of_Optimizations
