### PR TITLE
Fix issue where the date displayed by mat-datepicker was one day off  from what was specified in the JSON

### DIFF
--- a/src/lib/src/framework-library/material-design-framework/material-datepicker.component.ts
+++ b/src/lib/src/framework-library/material-design-framework/material-datepicker.component.ts
@@ -23,6 +23,7 @@ import { dateToString, hasOwn, stringToDate } from '../../shared';
         [placeholder]="options?.title"
         [required]="options?.required"
         [style.width]="'100%'"
+        [value]="dateValue"
         (blur)="options.showErrors = true">
       <input matInput *ngIf="!boundControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"


### PR DESCRIPTION
Fix issue where the date displayed by mat-datepicker was one day off from what was specified in the JSON

## PR Type
What changes does this PR include (check all that apply)?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->
The date displayed by mat-datepicker is one day off from the data in the JSON.

For example:
1. Navigate to [Angular JSON Schema Form — Demonstration Playground](https://angular2-json-schema-form.firebaseapp.com/)
2. Set the birthday property in the _Input JSON Schema Form Layout_ section to "1999-07-21"
3. Observe that in the _Generated Form_ section, the birthday displayed is "07/20/1999"

Notice that this is not an issue for the other design frameworks, which correctly display "07/21/1999".

## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->
Date displayed in the generated mat-datepicker matches the data in the JSON.

## Does this PR introduce a breaking change?
[ ] Yes
[x] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->


## Any other relevant information
At first, thought it was an issue with timezones and mat-datepicker (e.g. [here](https://github.com/angular/material2/issues/7167)). However, it appears that the functions in date.functions.ts were all working correctly to avoid timezone issues. 

Found that when the second matInput in the material-datepicker-widget component was used (the one with *ngIf="!boundControl"), this issue did not come up. 

Concluded that the reason this issue still exists is because although the dateValue property is computed correctly, it's not being used in the first matInput (the one with *ngIf="boundControl").